### PR TITLE
[Feature] 토큰 관리 구현 (#54)

### DIFF
--- a/src/app/auth/join/page.tsx
+++ b/src/app/auth/join/page.tsx
@@ -1,4 +1,4 @@
-import { JoinFunnel } from '@/features/auth/join/ui'
+import { JoinFunnel } from '@/features/auth'
 
 export default function Page() {
   return (

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import LoginPage from '@/features/auth/login/ui/page'
+import { LoginPage } from '@/features/auth'
 import { Suspense } from 'react'
 
 export default function Page() {

--- a/src/app/auth/social/kakao/page.tsx
+++ b/src/app/auth/social/kakao/page.tsx
@@ -1,4 +1,4 @@
-import { SocialCallback } from '@/features/auth/social/SocialCallback'
+import { SocialCallback } from '@/features/auth'
 import { Suspense } from 'react'
 
 export default function KakaoSocialPage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import localFont from 'next/font/local'
 import './globals.css'
-import { Header } from '@/shared/ui/header'
+import { HeaderWrapper } from '@/features/auth'
 import Footer from '@/shared/ui/Footer'
 import { Toaster } from '@/shared/ui/Toaster'
 import Providers from '@/app/providers'
@@ -26,7 +26,7 @@ const RootLayout = ({
     <html lang="ko" className={`${pretendard.variable} antialiased`}>
       <body className="font-pretendard flex min-h-screen flex-col">
         <Providers>
-          <Header isLoggedIn={false} />
+          <HeaderWrapper />
           <main className="flex-1">{children}</main>
           <Footer />
           <Toaster position="top-right" duration={1500} />

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,10 +1,21 @@
 'use client'
 
-import { getQueryClient } from '@/shared/api/query-client'
+import { useEffect } from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'
 
-const Providers = ({ children }: { children: React.ReactNode }) => {
+import { getQueryClient } from '@/shared/api/query-client'
+import { setupAuthInterceptors } from '@/features/auth/lib/setup-auth-interceptors'
+
+interface ProvidersProps {
+  children: React.ReactNode
+}
+
+const Providers = ({ children }: ProvidersProps) => {
   const queryClient = getQueryClient()
+
+  useEffect(() => {
+    setupAuthInterceptors()
+  }, [])
 
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/src/features/auth/api/endpoints/login.ts
+++ b/src/features/auth/api/endpoints/login.ts
@@ -10,6 +10,7 @@ export const postEmailLogin = async (
   body: EmailLoginRequest
 ): Promise<TokenResponse> => {
   const payload = EmailLoginRequestSchema.parse(body)
+
   const { data } = await api.post('/api/v1/auth/login', payload)
 
   return TokenResponseSchema.parse(data)

--- a/src/features/auth/api/endpoints/login.ts
+++ b/src/features/auth/api/endpoints/login.ts
@@ -2,16 +2,16 @@ import { api } from '@/shared/api/client'
 import {
   EmailLoginRequest,
   EmailLoginRequestSchema,
-  TokenResponse,
-  TokenResponseSchema,
+  EmailLoginResponse,
+  EmailLoginResponseSchema,
 } from '@/features/auth/api/schemas/login'
 
 export const postEmailLogin = async (
   body: EmailLoginRequest
-): Promise<TokenResponse> => {
+): Promise<EmailLoginResponse> => {
   const payload = EmailLoginRequestSchema.parse(body)
 
-  const { data } = await api.post('/api/v1/auth/login', payload)
+  const { data } = await api.post('/auth/login', payload)
 
-  return TokenResponseSchema.parse(data)
+  return EmailLoginResponseSchema.parse(data)
 }

--- a/src/features/auth/api/endpoints/login.ts
+++ b/src/features/auth/api/endpoints/login.ts
@@ -1,0 +1,16 @@
+import { api } from '@/shared/api/client'
+import {
+  EmailLoginRequest,
+  EmailLoginRequestSchema,
+  TokenResponse,
+  TokenResponseSchema,
+} from '@/features/auth/api/schemas/login'
+
+export const postEmailLogin = async (
+  body: EmailLoginRequest
+): Promise<TokenResponse> => {
+  const payload = EmailLoginRequestSchema.parse(body)
+  const { data } = await api.post('/api/v1/auth/login', payload)
+
+  return TokenResponseSchema.parse(data)
+}

--- a/src/features/auth/api/endpoints/oauth.ts
+++ b/src/features/auth/api/endpoints/oauth.ts
@@ -11,7 +11,7 @@ export const postKakaoOAuth = async (input: {
 }): Promise<KakaoOAuthResponse> => {
   const body = KakaoOAuthRequestSchema.parse(input)
 
-  const { data } = await axios.post('/api/v1/auth/oauth/kakao', body, {
+  const { data } = await axios.post('/auth/oauth/kakao', body, {
     headers: { 'Content-Type': 'application/json' },
     withCredentials: true,
   })

--- a/src/features/auth/api/endpoints/refresh.ts
+++ b/src/features/auth/api/endpoints/refresh.ts
@@ -11,7 +11,7 @@ export const postTokenRefresh = async (
 ): Promise<TokenRefreshResponse> => {
   const payload = TokenRefreshRequestSchema.parse(body ?? {})
 
-  const { data } = await api.post('/api/v1/auth/refresh', payload, {
+  const { data } = await api.post('/auth/refresh', payload, {
     withCredentials: true,
   })
 

--- a/src/features/auth/api/endpoints/refresh.ts
+++ b/src/features/auth/api/endpoints/refresh.ts
@@ -4,7 +4,7 @@ import {
   TokenRefreshRequestSchema,
   TokenRefreshResponse,
   TokenRefreshResponseSchema,
-} from '@/features/auth/api/schemas/auth/refresh'
+} from '@/features/auth/api/schemas/login/refresh'
 
 export const postTokenRefresh = async (
   body?: TokenRefreshRequest

--- a/src/features/auth/api/endpoints/refresh.ts
+++ b/src/features/auth/api/endpoints/refresh.ts
@@ -1,0 +1,19 @@
+import { api } from '@/shared/api/client'
+import {
+  TokenRefreshRequest,
+  TokenRefreshRequestSchema,
+  TokenRefreshResponse,
+  TokenRefreshResponseSchema,
+} from '@/features/auth/api/schemas/auth/refresh'
+
+export const postTokenRefresh = async (
+  body?: TokenRefreshRequest
+): Promise<TokenRefreshResponse> => {
+  const payload = TokenRefreshRequestSchema.parse(body ?? {})
+
+  const { data } = await api.post('/api/v1/auth/refresh', payload, {
+    withCredentials: true,
+  })
+
+  return TokenRefreshResponseSchema.parse(data)
+}

--- a/src/features/auth/api/schemas/login/common.ts
+++ b/src/features/auth/api/schemas/login/common.ts
@@ -35,7 +35,13 @@ export const UserSchema = z
     provider: UserProviderSchema.optional(),
   })
   .transform((data) => ({
-    ...data,
+    id: data.id,
+    email: data.email,
+    nickname: data.nickname,
+    name: data.name,
+    role: data.role,
+    status: data.status,
+    provider: data.provider,
     profileImageUrl: data.profile_image_url ?? null,
   }))
 export type User = z.infer<typeof UserSchema>

--- a/src/features/auth/api/schemas/login/common.ts
+++ b/src/features/auth/api/schemas/login/common.ts
@@ -13,7 +13,7 @@ export const UserProviderSchema = z.enum(['EMAIL', 'KAKAO', 'GOOGLE'])
 export const TokenResponseSchema = z
   .object({
     access_token: z.string(),
-    token_type: z.literal('Bearer'),
+    token_type: z.string(),
     expires_in: z.number().int().positive(),
   })
   .transform((data) => ({
@@ -29,7 +29,7 @@ export const UserSchema = z
     email: z.string().email(),
     nickname: z.string(),
     name: z.string(),
-    profile_image_url: z.string().url().nullable().optional(),
+    profile_image_url: z.string().url().nullable(),
     role: UserRoleSchema,
     status: UserStatusSchema,
     provider: UserProviderSchema.optional(),

--- a/src/features/auth/api/schemas/login/common.ts
+++ b/src/features/auth/api/schemas/login/common.ts
@@ -4,17 +4,11 @@ export const ErrorResponseSchema = z.object({
   error_code: z.string(),
   error_detail: z.string(),
 })
-
 export type ErrorResponse = z.infer<typeof ErrorResponseSchema>
 
 export const UserRoleSchema = z.enum(['USER', 'ADMIN'])
-export type UserRole = z.infer<typeof UserRoleSchema>
-
 export const UserStatusSchema = z.enum(['ACTIVE', 'BANNED', 'WITHDRAWN'])
-export type UserStatus = z.infer<typeof UserStatusSchema>
-
 export const UserProviderSchema = z.enum(['EMAIL', 'KAKAO', 'GOOGLE'])
-export type UserProvider = z.infer<typeof UserProviderSchema>
 
 export const TokenResponseSchema = z
   .object({
@@ -27,7 +21,6 @@ export const TokenResponseSchema = z
     tokenType: data.token_type,
     expiresIn: data.expires_in,
   }))
-
 export type TokenResponse = z.infer<typeof TokenResponseSchema>
 
 export const UserSchema = z
@@ -42,14 +35,7 @@ export const UserSchema = z
     provider: UserProviderSchema.optional(),
   })
   .transform((data) => ({
-    id: data.id,
-    email: data.email,
-    nickname: data.nickname,
-    name: data.name,
+    ...data,
     profileImageUrl: data.profile_image_url ?? null,
-    role: data.role,
-    status: data.status,
-    provider: data.provider,
   }))
-
 export type User = z.infer<typeof UserSchema>

--- a/src/features/auth/api/schemas/login/find-email.ts
+++ b/src/features/auth/api/schemas/login/find-email.ts
@@ -5,8 +5,8 @@ import {
 } from '@/features/auth/api/schemas/login/common'
 
 export const FindEmailSendCodeRequestSchema = z.object({
-  name: z.string().min(1),
-  phone: z.string().min(8),
+  name: z.string().min(1, '이름을 입력해주세요.'),
+  phone: z.string().min(8, '올바른 휴대폰 번호를 입력해주세요.'),
 })
 
 export type FindEmailSendCodeRequest = z.infer<
@@ -35,11 +35,10 @@ export type FindEmailSendCodeError = z.infer<
   typeof FindEmailSendCodeErrorSchema
 >
 
-// POST /api/v1/auth/find-email/verify
 export const FindEmailVerifyRequestSchema = z.object({
-  name: z.string().min(1),
-  phone: z.string().min(8),
-  code: z.string().length(6),
+  name: z.string().min(1, '이름을 입력해주세요.'),
+  phone: z.string().min(8, '올바른 휴대폰 번호를 입력해주세요.'),
+  code: z.string().length(6, '인증번호 6자리를 입력해주세요.'),
 })
 
 export type FindEmailVerifyRequest = z.infer<
@@ -71,7 +70,13 @@ export type FindEmailVerifyResponse = z.infer<
 >
 
 export const FindEmailVerifyErrorSchema = ErrorResponseSchema.extend({
-  error_code: z.enum(['INVALID_CODE', 'USER_NOT_FOUND']),
+  error_code: z.enum([
+    'INVALID_CODE',
+    'USER_NOT_FOUND',
+    'INVALID_NICKNAME_LENGTH', // 명세서 비고란의 에러코드 포함
+    'INVALID_NICKNAME_FORMAT',
+    'NICKNAME_ALREADY_EXISTS',
+  ]),
 })
 
 export type FindEmailVerifyError = z.infer<typeof FindEmailVerifyErrorSchema>

--- a/src/features/auth/api/schemas/login/index.ts
+++ b/src/features/auth/api/schemas/login/index.ts
@@ -16,54 +16,58 @@ export {
   TokenRefreshRequestSchema,
   TokenRefreshResponseSchema,
   TokenRefreshErrorSchema,
-} from './refresh'
+} from '@/features/auth/api/schemas/login/refresh'
 export type {
   TokenRefreshRequest,
   TokenRefreshResponse,
   TokenRefreshError,
-} from './refresh'
+} from '@/features/auth/api/schemas/login/refresh'
 
 export {
   LogoutRequestSchema,
   LogoutResponseSchema,
   LogoutErrorSchema,
-} from './logout'
-export type { LogoutRequest, LogoutResponse, LogoutError } from './logout'
+} from '@/features/auth/api/schemas/login/logout'
+export type {
+  LogoutRequest,
+  LogoutResponse,
+  LogoutError,
+} from '@/features/auth/api/schemas/login/logout'
 
 export {
   FindEmailSendCodeRequestSchema,
   FindEmailSendCodeResponseSchema,
   FindEmailVerifyRequestSchema,
   FindEmailVerifyResponseSchema,
-} from './find-email'
+} from '@/features/auth/api/schemas/login/find-email'
 export type {
   FindEmailSendCodeRequest,
   FindEmailSendCodeResponse,
   FindEmailVerifyRequest,
   FindEmailVerifyResponse,
-} from './find-email'
+} from '@/features/auth/api/schemas/login/find-email'
 
 export {
   NicknameCheckRequestSchema,
   NicknameCheckResponseSchema,
   NicknameCheckErrorSchema,
-} from './nickname'
+} from '@/features/auth/api/schemas/login/nickname'
 export type {
   NicknameCheckRequest,
   NicknameCheckResponse,
   NicknameCheckError,
-} from './nickname'
+} from '@/features/auth/api/schemas/login/nickname'
 
 export {
   PasswordResetRequestSchema,
   PasswordResetResponseSchema,
   PasswordResetErrorSchema,
-} from './password-reset'
+} from '@/features/auth/api/schemas/login/password-reset'
 export type {
   PasswordResetRequest,
   PasswordResetResponse,
   PasswordResetError,
-} from './password-reset'
+} from '@/features/auth/api/schemas/login/password-reset'
 
-export { WithdrawalInfoResponseSchema } from './withdrawal'
-export type { WithdrawalInfoResponse } from './withdrawal'
+export { WithdrawalInfoResponseSchema } from '@/features/auth/api/schemas/login/withdrawal'
+export type { WithdrawalInfoResponse } from '@/features/auth/api/schemas/login/withdrawal'

--- a/src/features/auth/api/schemas/login/index.ts
+++ b/src/features/auth/api/schemas/login/index.ts
@@ -1,14 +1,69 @@
-export { EmailLoginRequestSchema, EmailLoginResponseSchema } from './login'
-export type { EmailLoginRequest, EmailLoginResponse } from './login' // 타입 추가
+export {
+  UserSchema,
+  TokenResponseSchema,
+  ErrorResponseSchema,
+} from '@/features/auth/api/schemas/login/common'
+
+export type {
+  User,
+  TokenResponse,
+  ErrorResponse,
+} from '@/features/auth/api/schemas/login/common'
+
+export * from '@/features/auth/api/schemas/login/login'
 
 export {
   TokenRefreshRequestSchema,
   TokenRefreshResponseSchema,
+  TokenRefreshErrorSchema,
 } from './refresh'
-export type { TokenRefreshRequest, TokenRefreshResponse } from './refresh' // 타입 추가
+export type {
+  TokenRefreshRequest,
+  TokenRefreshResponse,
+  TokenRefreshError,
+} from './refresh'
 
-export { LogoutRequestSchema, LogoutResponseSchema } from './logout'
-export type { LogoutRequest, LogoutResponse } from './logout' // 타입 추가
+export {
+  LogoutRequestSchema,
+  LogoutResponseSchema,
+  LogoutErrorSchema,
+} from './logout'
+export type { LogoutRequest, LogoutResponse, LogoutError } from './logout'
 
-export { UserSchema, TokenResponseSchema } from './common'
-export type { User, TokenResponse } from './common' // 타입 추가
+export {
+  FindEmailSendCodeRequestSchema,
+  FindEmailSendCodeResponseSchema,
+  FindEmailVerifyRequestSchema,
+  FindEmailVerifyResponseSchema,
+} from './find-email'
+export type {
+  FindEmailSendCodeRequest,
+  FindEmailSendCodeResponse,
+  FindEmailVerifyRequest,
+  FindEmailVerifyResponse,
+} from './find-email'
+
+export {
+  NicknameCheckRequestSchema,
+  NicknameCheckResponseSchema,
+  NicknameCheckErrorSchema,
+} from './nickname'
+export type {
+  NicknameCheckRequest,
+  NicknameCheckResponse,
+  NicknameCheckError,
+} from './nickname'
+
+export {
+  PasswordResetRequestSchema,
+  PasswordResetResponseSchema,
+  PasswordResetErrorSchema,
+} from './password-reset'
+export type {
+  PasswordResetRequest,
+  PasswordResetResponse,
+  PasswordResetError,
+} from './password-reset'
+
+export { WithdrawalInfoResponseSchema } from './withdrawal'
+export type { WithdrawalInfoResponse } from './withdrawal'

--- a/src/features/auth/api/schemas/login/index.ts
+++ b/src/features/auth/api/schemas/login/index.ts
@@ -1,16 +1,14 @@
-export {
-  EmailLoginRequestSchema,
-  EmailLoginResponseSchema,
-} from '@/features/auth/api/schemas/login/login'
+export { EmailLoginRequestSchema, EmailLoginResponseSchema } from './login'
+export type { EmailLoginRequest, EmailLoginResponse } from './login' // 타입 추가
+
 export {
   TokenRefreshRequestSchema,
   TokenRefreshResponseSchema,
-} from '@/features/auth/api/schemas/login/refresh'
-export {
-  LogoutRequestSchema,
-  LogoutResponseSchema,
-} from '@/features/auth/api/schemas/login/logout'
-export {
-  UserSchema,
-  TokenResponseSchema,
-} from '@/features/auth/api/schemas/login/common'
+} from './refresh'
+export type { TokenRefreshRequest, TokenRefreshResponse } from './refresh' // 타입 추가
+
+export { LogoutRequestSchema, LogoutResponseSchema } from './logout'
+export type { LogoutRequest, LogoutResponse } from './logout' // 타입 추가
+
+export { UserSchema, TokenResponseSchema } from './common'
+export type { User, TokenResponse } from './common' // 타입 추가

--- a/src/features/auth/api/schemas/login/login.ts
+++ b/src/features/auth/api/schemas/login/login.ts
@@ -1,8 +1,7 @@
-// src/shared/api/schemas/auth/login.ts
 import z from 'zod'
 import {
-  ErrorResponseSchema,
   UserSchema,
+  ErrorResponseSchema,
 } from '@/features/auth/api/schemas/login/common'
 
 export const EmailLoginRequestSchema = z.object({
@@ -10,7 +9,6 @@ export const EmailLoginRequestSchema = z.object({
   password: z.string().min(1),
   remember_me: z.boolean().optional(),
 })
-
 export type EmailLoginRequest = z.infer<typeof EmailLoginRequestSchema>
 
 export const EmailLoginResponseSchema = z
@@ -18,23 +16,18 @@ export const EmailLoginResponseSchema = z
     access_token: z.string(),
     token_type: z.literal('Bearer'),
     expires_in: z.number().int().positive(),
-    user: z.any(),
+    user: UserSchema,
   })
-  .transform((data) => {
-    const user = UserSchema.parse(data.user)
-
-    return {
-      accessToken: data.access_token,
-      tokenType: data.token_type,
-      expiresIn: data.expires_in,
-      user,
-    }
-  })
-
+  .transform((data) => ({
+    accessToken: data.access_token,
+    tokenType: data.token_type,
+    expiresIn: data.expires_in,
+    user: data.user,
+  }))
 export type EmailLoginResponse = z.infer<typeof EmailLoginResponseSchema>
 
-export const LoginInvalidCredentialsErrorSchema = ErrorResponseSchema.extend({
-  error_code: z.literal('INVALID_CREDENTIALS'),
+export const LoginInvalidCredentialsErrorSchema = z.object({
+  detail: z.string(),
 })
 
 export const LoginAccountWithdrawnErrorSchema = ErrorResponseSchema.extend({
@@ -42,22 +35,11 @@ export const LoginAccountWithdrawnErrorSchema = ErrorResponseSchema.extend({
   can_restore: z.boolean(),
   restore_deadline: z.string(),
 }).transform((data) => ({
-  errorCode: data.error_code,
-  errorDetail: data.error_detail,
-  canRestore: data.can_restore,
+  ...data,
   restoreDeadline: new Date(data.restore_deadline),
 }))
 
 export const LoginBlockedErrorSchema = ErrorResponseSchema.extend({
   error_code: z.literal('LOGIN_BLOCKED'),
   retry_after: z.number().int().positive(),
-}).transform((data) => ({
-  errorCode: data.error_code,
-  errorDetail: data.error_detail,
-  retryAfter: data.retry_after,
-}))
-
-export type LoginAccountWithdrawnError = z.infer<
-  typeof LoginAccountWithdrawnErrorSchema
->
-export type LoginBlockedError = z.infer<typeof LoginBlockedErrorSchema>
+})

--- a/src/features/auth/api/schemas/login/login.ts
+++ b/src/features/auth/api/schemas/login/login.ts
@@ -22,7 +22,16 @@ export const EmailLoginResponseSchema = z
     accessToken: data.access_token,
     tokenType: data.token_type,
     expiresIn: data.expires_in,
-    user: data.user,
+    user: {
+      id: data.user.id,
+      email: data.user.email,
+      nickname: data.user.nickname,
+      name: data.user.name,
+      role: data.user.role,
+      status: data.user.status,
+      provider: data.user.provider,
+      profileImageUrl: data.user.profileImageUrl ?? null,
+    },
   }))
 export type EmailLoginResponse = z.infer<typeof EmailLoginResponseSchema>
 
@@ -35,7 +44,9 @@ export const LoginAccountWithdrawnErrorSchema = ErrorResponseSchema.extend({
   can_restore: z.boolean(),
   restore_deadline: z.string(),
 }).transform((data) => ({
-  ...data,
+  error_code: data.error_code,
+  error_detail: data.error_detail,
+  can_restore: data.can_restore,
   restoreDeadline: new Date(data.restore_deadline),
 }))
 

--- a/src/features/auth/api/schemas/login/logout.ts
+++ b/src/features/auth/api/schemas/login/logout.ts
@@ -2,19 +2,16 @@ import z from 'zod'
 import { ErrorResponseSchema } from '@/features/auth/api/schemas/login/common'
 
 export const LogoutRequestSchema = z.object({
-  all_devices: z.boolean().optional(),
+  all_devices: z.boolean().optional().default(false),
 })
-
 export type LogoutRequest = z.infer<typeof LogoutRequestSchema>
 
 export const LogoutResponseSchema = z.object({
   message: z.string(),
 })
-
 export type LogoutResponse = z.infer<typeof LogoutResponseSchema>
 
 export const LogoutErrorSchema = ErrorResponseSchema.extend({
   error_code: z.enum(['INVALID_TOKEN', 'TOKEN_EXPIRED', 'TOKEN_REVOKED']),
 })
-
 export type LogoutError = z.infer<typeof LogoutErrorSchema>

--- a/src/features/auth/api/schemas/login/nickname.ts
+++ b/src/features/auth/api/schemas/login/nickname.ts
@@ -4,14 +4,12 @@ import { ErrorResponseSchema } from '@/features/auth/api/schemas/login/common'
 export const NicknameCheckRequestSchema = z.object({
   nickname: z.string().min(1),
 })
-
 export type NicknameCheckRequest = z.infer<typeof NicknameCheckRequestSchema>
 
 export const NicknameCheckResponseSchema = z.object({
   available: z.boolean(),
   message: z.string(),
 })
-
 export type NicknameCheckResponse = z.infer<typeof NicknameCheckResponseSchema>
 
 export const NicknameCheckErrorSchema = ErrorResponseSchema.extend({
@@ -21,11 +19,6 @@ export const NicknameCheckErrorSchema = ErrorResponseSchema.extend({
     'NICKNAME_ALREADY_EXISTS',
     'TOO_MANY_REQUEST',
   ]),
-  retry_after: z.number().int().positive().optional(),
-}).transform((data) => ({
-  errorCode: data.error_code,
-  errorDetail: data.error_detail,
-  retryAfter: data.retry_after,
-}))
-
+  retry_after: z.number().optional(),
+})
 export type NicknameCheckError = z.infer<typeof NicknameCheckErrorSchema>

--- a/src/features/auth/api/schemas/login/password-reset.ts
+++ b/src/features/auth/api/schemas/login/password-reset.ts
@@ -6,13 +6,11 @@ export const PasswordResetRequestSchema = z.object({
   new_password: z.string().min(1),
   new_password_confirm: z.string().min(1),
 })
-
 export type PasswordResetRequest = z.infer<typeof PasswordResetRequestSchema>
 
 export const PasswordResetResponseSchema = z.object({
   message: z.string(),
 })
-
 export type PasswordResetResponse = z.infer<typeof PasswordResetResponseSchema>
 
 export const PasswordResetErrorSchema = ErrorResponseSchema.extend({
@@ -26,11 +24,5 @@ export const PasswordResetErrorSchema = ErrorResponseSchema.extend({
     'PASSWORD_RECENTLY_USED',
     'TOO_MANY_REQUEST',
   ]),
-  retry_after: z.number().int().positive().optional(),
-}).transform((data) => ({
-  errorCode: data.error_code,
-  errorDetail: data.error_detail,
-  retryAfter: data.retry_after,
-}))
-
+})
 export type PasswordResetError = z.infer<typeof PasswordResetErrorSchema>

--- a/src/features/auth/api/schemas/login/refresh.ts
+++ b/src/features/auth/api/schemas/login/refresh.ts
@@ -7,7 +7,6 @@ import {
 export const TokenRefreshRequestSchema = z.object({
   refresh_token: z.string().optional(),
 })
-
 export type TokenRefreshRequest = z.infer<typeof TokenRefreshRequestSchema>
 
 export const TokenRefreshResponseSchema = TokenResponseSchema
@@ -20,5 +19,4 @@ export const TokenRefreshErrorSchema = ErrorResponseSchema.extend({
     'TOKEN_REVOKED',
   ]),
 })
-
 export type TokenRefreshError = z.infer<typeof TokenRefreshErrorSchema>

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,0 +1,8 @@
+export { setupAuthInterceptors } from '@/features/auth/lib/setup-auth-interceptors'
+export {
+  setAccessToken,
+  getAccessToken,
+  clearAccessToken,
+} from '@/features/auth/model/store/token-store'
+export { JoinFunnel } from '@/features/auth/join/ui'
+export { SocialCallback } from '@/features/auth/social/SocialCallback'

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -6,3 +6,4 @@ export {
 } from '@/features/auth/model/store/token-store'
 export { JoinFunnel } from '@/features/auth/join/ui'
 export { SocialCallback } from '@/features/auth/social/SocialCallback'
+export { default as LoginPage } from '@/features/auth/login/ui/page'

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,9 +1,5 @@
 export { setupAuthInterceptors } from '@/features/auth/lib/setup-auth-interceptors'
-export {
-  setAccessToken,
-  getAccessToken,
-  clearAccessToken,
-} from '@/features/auth/model/store/token-store'
+export { useTokenStore } from '@/features/auth/model/store/token-store'
 export { JoinFunnel } from '@/features/auth/join/ui'
 export { SocialCallback } from '@/features/auth/social/SocialCallback'
 export { default as LoginPage } from '@/features/auth/login/ui/page'

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -7,3 +7,4 @@ export {
 export { JoinFunnel } from '@/features/auth/join/ui'
 export { SocialCallback } from '@/features/auth/social/SocialCallback'
 export { default as LoginPage } from '@/features/auth/login/ui/page'
+export { HeaderWrapper } from '@/features/auth/ui/HeaderWrapper'

--- a/src/features/auth/lib/setup-auth-interceptors.ts
+++ b/src/features/auth/lib/setup-auth-interceptors.ts
@@ -2,11 +2,7 @@ import type { AxiosError, InternalAxiosRequestConfig } from 'axios'
 
 import { api } from '@/shared/api/client'
 import { postTokenRefresh } from '@/features/auth/api/endpoints/refresh'
-import {
-  clearAccessToken,
-  getAccessToken,
-  setAccessToken,
-} from '@/features/auth/model/store/token-store'
+import { useTokenStore } from '@/features/auth/model/store/token-store'
 
 interface RetriableRequestConfig extends InternalAxiosRequestConfig {
   _retry?: boolean
@@ -20,10 +16,10 @@ export const setupAuthInterceptors = () => {
   isInterceptorInstalled = true
 
   api.interceptors.request.use((config) => {
-    const token = getAccessToken()
-    if (token) {
+    const { accessToken } = useTokenStore.getState()
+    if (accessToken) {
       config.headers = config.headers ?? {}
-      config.headers.Authorization = `Bearer ${token}`
+      config.headers.Authorization = `Bearer ${accessToken}`
     }
     return config
   })
@@ -39,7 +35,7 @@ export const setupAuthInterceptors = () => {
       }
 
       if (originalRequest.url?.includes('/auth/refresh')) {
-        clearAccessToken()
+        useTokenStore.getState().clearAccessToken()
         throw error
       }
 
@@ -52,7 +48,9 @@ export const setupAuthInterceptors = () => {
         if (!refreshAccessTokenPromise) {
           refreshAccessTokenPromise = postTokenRefresh()
             .then((refreshResponse) => {
-              setAccessToken(refreshResponse.accessToken)
+              useTokenStore
+                .getState()
+                .setAccessToken(refreshResponse.accessToken)
               return refreshResponse.accessToken
             })
             .finally(() => {
@@ -67,7 +65,7 @@ export const setupAuthInterceptors = () => {
 
         return api(originalRequest)
       } catch (refreshError) {
-        clearAccessToken()
+        useTokenStore.getState().clearAccessToken()
         throw refreshError
       }
     }

--- a/src/features/auth/lib/setup-auth-interceptors.ts
+++ b/src/features/auth/lib/setup-auth-interceptors.ts
@@ -38,7 +38,7 @@ export const setupAuthInterceptors = () => {
         throw error
       }
 
-      if (originalRequest.url?.includes('/api/v1/auth/refresh')) {
+      if (originalRequest.url?.includes('/auth/refresh')) {
         clearAccessToken()
         throw error
       }
@@ -52,7 +52,6 @@ export const setupAuthInterceptors = () => {
         if (!refreshAccessTokenPromise) {
           refreshAccessTokenPromise = postTokenRefresh()
             .then((refreshResponse) => {
-              // ✅ 타입이 camelCase라서 accessToken 사용
               setAccessToken(refreshResponse.accessToken)
               return refreshResponse.accessToken
             })

--- a/src/features/auth/lib/setup-auth-interceptors.ts
+++ b/src/features/auth/lib/setup-auth-interceptors.ts
@@ -1,0 +1,76 @@
+import type { AxiosError, InternalAxiosRequestConfig } from 'axios'
+
+import { api } from '@/shared/api/client'
+import { postTokenRefresh } from '@/features/auth/api/endpoints/refresh'
+import {
+  clearAccessToken,
+  getAccessToken,
+  setAccessToken,
+} from '@/features/auth/model/store/token-store'
+
+interface RetriableRequestConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean
+}
+
+let refreshAccessTokenPromise: Promise<string> | null = null
+let isInterceptorInstalled = false
+
+export const setupAuthInterceptors = () => {
+  if (isInterceptorInstalled) return
+  isInterceptorInstalled = true
+
+  api.interceptors.request.use((config) => {
+    const token = getAccessToken()
+    if (token) {
+      config.headers = config.headers ?? {}
+      config.headers.Authorization = `Bearer ${token}`
+    }
+    return config
+  })
+
+  api.interceptors.response.use(
+    (response) => response,
+    async (error: AxiosError) => {
+      const statusCode = error.response?.status
+      const originalRequest = error.config as RetriableRequestConfig | undefined
+
+      if (!originalRequest || statusCode !== 401) {
+        throw error
+      }
+
+      if (originalRequest.url?.includes('/api/v1/auth/refresh')) {
+        clearAccessToken()
+        throw error
+      }
+
+      if (originalRequest._retry) {
+        throw error
+      }
+      originalRequest._retry = true
+
+      try {
+        if (!refreshAccessTokenPromise) {
+          refreshAccessTokenPromise = postTokenRefresh()
+            .then((refreshResponse) => {
+              // ✅ 타입이 camelCase라서 accessToken 사용
+              setAccessToken(refreshResponse.accessToken)
+              return refreshResponse.accessToken
+            })
+            .finally(() => {
+              refreshAccessTokenPromise = null
+            })
+        }
+
+        const newAccessToken = await refreshAccessTokenPromise
+
+        originalRequest.headers = originalRequest.headers ?? {}
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`
+
+        return api(originalRequest)
+      } catch (refreshError) {
+        clearAccessToken()
+        throw refreshError
+      }
+    }
+  )
+}

--- a/src/features/auth/login/hooks/useLoginMutation.ts
+++ b/src/features/auth/login/hooks/useLoginMutation.ts
@@ -1,0 +1,47 @@
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useMutation } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { AxiosError } from 'axios'
+
+import { useTokenStore } from '@/features/auth'
+import { postEmailLogin } from '@/features/auth/api/endpoints/login'
+import {
+  EmailLoginRequest,
+  EmailLoginResponse,
+  LoginInvalidCredentialsErrorSchema,
+  LoginAccountWithdrawnErrorSchema,
+  LoginBlockedErrorSchema,
+} from '@/features/auth/api/schemas/login'
+
+export function useLoginMutation() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const next = searchParams.get('next')
+
+  return useMutation<EmailLoginResponse, AxiosError, EmailLoginRequest>({
+    mutationFn: postEmailLogin,
+    onSuccess: (response) => {
+      if (response.accessToken) {
+        useTokenStore.getState().setAccessToken(response.accessToken)
+      }
+      toast.success(`${response.user.nickname}님, 환영합니다!`)
+      const redirectPath = next ? decodeURIComponent(next) : '/'
+      router.replace(redirectPath)
+      router.refresh()
+    },
+    onError: (error) => {
+      const errorData = error.response?.data
+      const invalid = LoginInvalidCredentialsErrorSchema.safeParse(errorData)
+      if (invalid.success) return toast.error(invalid.data.detail)
+      const blocked = LoginBlockedErrorSchema.safeParse(errorData)
+      if (blocked.success)
+        return toast.error(
+          `${blocked.data.error_detail} (대기: ${blocked.data.retry_after}초)`
+        )
+      const withdrawn = LoginAccountWithdrawnErrorSchema.safeParse(errorData)
+      if (withdrawn.success)
+        return toast.error(`${withdrawn.data.error_detail}`)
+      toast.error('로그인 정보가 일치하지 않거나 오류가 발생했습니다.')
+    },
+  })
+}

--- a/src/features/auth/login/ui/LoginForm.tsx
+++ b/src/features/auth/login/ui/LoginForm.tsx
@@ -1,26 +1,15 @@
 'use client'
 
 import Link from 'next/link'
-import { useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useEffect } from 'react'
+import { useEffect } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { toast } from 'sonner'
-import { AxiosError } from 'axios'
 
 import { Button } from '@/shared/ui/Button'
 import { Input } from '@/shared/ui/input'
 
-import { setAccessToken } from '@/features/auth'
-import { postEmailLogin } from '@/features/auth/api/endpoints/login'
-import {
-  EmailLoginRequest,
-  EmailLoginResponse,
-  LoginInvalidCredentialsErrorSchema,
-  LoginAccountWithdrawnErrorSchema,
-  LoginBlockedErrorSchema,
-} from '@/features/auth/api/schemas/login'
+import { useLoginMutation } from '../hooks/useLoginMutation'
 
 const SAVED_EMAIL_KEY = 'studigo.saved_login_email'
 
@@ -72,10 +61,6 @@ const loginFormSchema = z
 type LoginFormValues = z.infer<typeof loginFormSchema>
 
 export default function LoginForm() {
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const next = searchParams.get('next')
-
   const {
     register,
     handleSubmit,
@@ -120,50 +105,15 @@ export default function LoginForm() {
     }
   }, [remember, email])
 
-  const onSubmit = useCallback(
-    async (values: LoginFormValues) => {
-      const payload: EmailLoginRequest = {
-        email: values.email,
-        password: values.password,
-        remember_me: values.remember ?? false,
-      }
+  const loginMutation = useLoginMutation()
 
-      try {
-        const response = (await postEmailLogin(payload)) as EmailLoginResponse
-
-        if (response.accessToken) {
-          setAccessToken(response.accessToken)
-        }
-
-        toast.success(`${response.user.nickname}님, 환영합니다!`)
-
-        const redirectPath = next ? decodeURIComponent(next) : '/'
-        router.replace(redirectPath)
-        router.refresh()
-      } catch (error) {
-        const axiosError = error as AxiosError
-        const errorData = axiosError.response?.data
-
-        const invalid = LoginInvalidCredentialsErrorSchema.safeParse(errorData)
-        if (invalid.success) return toast.error(invalid.data.detail)
-
-        const blocked = LoginBlockedErrorSchema.safeParse(errorData)
-        if (blocked.success)
-          return toast.error(
-            `${blocked.data.error_detail} (대기: ${blocked.data.retry_after}초)`
-          )
-
-        const withdrawn = LoginAccountWithdrawnErrorSchema.safeParse(errorData)
-        if (withdrawn.success)
-          return toast.error(
-            `${withdrawn.data.error_detail} (복구 기한: ${withdrawn.data.restoreDeadline.toLocaleDateString()})`
-          )
-
-        toast.error('로그인 정보가 일치하지 않거나 오류가 발생했습니다.')
-      }
-    },
-    [router, next]
-  )
+  function onSubmit(values: LoginFormValues) {
+    loginMutation.mutate({
+      email: values.email,
+      password: values.password,
+      remember_me: values.remember ?? false,
+    })
+  }
 
   const isDisabled = !isValid || isSubmitting
 

--- a/src/features/auth/login/ui/LoginForm.tsx
+++ b/src/features/auth/login/ui/LoginForm.tsx
@@ -7,11 +7,17 @@ import { useForm, useWatch } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { toast } from 'sonner'
-import axios, { AxiosError } from 'axios'
+import { AxiosError } from 'axios'
 
 import { Button } from '@/shared/ui/Button'
 import { Input } from '@/shared/ui/input'
-import { EmailLoginRequestSchema } from '@/features/auth/api/schemas/login'
+
+import { setAccessToken } from '@/features/auth'
+import { postEmailLogin } from '@/features/auth/api/endpoints/login'
+import {
+  EmailLoginRequest,
+  TokenResponse,
+} from '@/features/auth/api/schemas/login'
 
 const SAVED_EMAIL_KEY = 'studigo.saved_login_email'
 
@@ -22,14 +28,50 @@ const ErrorResponseSchema = z.object({
 })
 type ErrorResponse = z.infer<typeof ErrorResponseSchema>
 
-const loginFormSchema = z.object({
-  email: z
-    .string()
-    .min(1, '이메일을 입력해주세요.')
-    .email('이메일 형식에 맞춰 작성해주세요.'),
-  password: z.string().min(1, '비밀번호를 입력해주세요.'),
-  remember: z.boolean().optional(),
-})
+const loginFormSchema = z
+  .object({
+    email: z
+      .string()
+      .min(1, '이메일을 입력해주세요.')
+      .email('이메일 형식에 맞춰 작성해주세요.'),
+    password: z
+      .string()
+      .min(1, '비밀번호를 입력해주세요.')
+      .min(8, '비밀번호는 8자 이상이어야 합니다.')
+      .max(20, '비밀번호는 20자 이하이어야 합니다.')
+      .regex(
+        /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*])/,
+        '영문 소문자, 숫자, 특수문자(!@#$%^&*)를 모두 포함해야 합니다.'
+      ),
+    remember: z.boolean().optional(),
+  })
+  .superRefine(({ password, email }, ctx) => {
+    if (password === email) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '이메일과 동일한 비밀번호는 사용할 수 없습니다.',
+        path: ['password'],
+      })
+    }
+
+    for (let i = 0; i < password.length - 2; i++) {
+      const char1 = password.charCodeAt(i)
+      const char2 = password.charCodeAt(i + 1)
+      const char3 = password.charCodeAt(i + 2)
+
+      if (
+        (char1 + 1 === char2 && char2 + 1 === char3) ||
+        (char1 - 1 === char2 && char2 - 1 === char3)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: '연속된 문자나 숫자를 3자 이상 사용할 수 없습니다.',
+          path: ['password'],
+        })
+        break
+      }
+    }
+  })
 
 type LoginFormValues = z.infer<typeof loginFormSchema>
 
@@ -60,7 +102,6 @@ export default function LoginForm() {
 
     try {
       const parsed: { email: string; remember: boolean } = JSON.parse(raw)
-
       if (parsed.remember) {
         setValue('email', parsed.email, { shouldValidate: true })
         setValue('remember', true)
@@ -74,48 +115,47 @@ export default function LoginForm() {
   const email = useWatch({ control, name: 'email' })
 
   useEffect(() => {
-    if (remember) {
-      if (email) {
-        localStorage.setItem(
-          SAVED_EMAIL_KEY,
-          JSON.stringify({ email, remember: true })
-        )
-      }
-    } else {
+    if (remember && email) {
+      localStorage.setItem(
+        SAVED_EMAIL_KEY,
+        JSON.stringify({ email, remember: true })
+      )
+    } else if (!remember) {
       localStorage.removeItem(SAVED_EMAIL_KEY)
     }
   }, [remember, email])
 
   const onSubmit = useCallback(
     async (values: LoginFormValues) => {
-      const request = EmailLoginRequestSchema.safeParse({
+      const payload: EmailLoginRequest = {
         email: values.email,
         password: values.password,
         remember_me: values.remember ?? false,
-      })
-
-      if (!request.success) {
-        toast.error('입력값을 확인해주세요.')
-        return
       }
 
       try {
-        await axios.post('/api/v1/auth/login', request.data, {
-          withCredentials: true,
-        })
+        const response: TokenResponse = await postEmailLogin(payload)
+
+        if (response.accessToken) {
+          setAccessToken(response.accessToken)
+        }
 
         toast.success('로그인에 성공했습니다.')
-        router.replace(next ? decodeURIComponent(next) : '/')
+
+        const redirectPath = next ? decodeURIComponent(next) : '/'
+        router.replace(redirectPath)
       } catch (error) {
         const axiosError = error as AxiosError<unknown>
-        const parsed = ErrorResponseSchema.safeParse(axiosError.response?.data)
+        const parsedError = ErrorResponseSchema.safeParse(
+          axiosError.response?.data
+        )
 
-        if (!parsed.success) {
-          toast.error('로그인에 실패했습니다.')
+        if (!parsedError.success) {
+          toast.error('로그인 중 알 수 없는 오류가 발생했습니다.')
           return
         }
 
-        const err: ErrorResponse = parsed.data
+        const err: ErrorResponse = parsedError.data
 
         switch (err.error_code) {
           case 'INVALID_CREDENTIALS':
@@ -129,12 +169,12 @@ export default function LoginForm() {
             break
           case 'LOGIN_BLOCKED':
             toast.error(
-              err.error_detail ??
+              err.error_detail ||
                 '로그인 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.'
             )
             break
           default:
-            toast.error(err.error_detail ?? '로그인에 실패했습니다.')
+            toast.error(err.error_detail || '로그인에 실패했습니다.')
         }
       }
     },
@@ -186,10 +226,13 @@ export default function LoginForm() {
           <input
             id="remember"
             type="checkbox"
-            className="border-brand-gray-300 h-4 w-4 rounded"
+            className="border-brand-gray-300 h-4 w-4 cursor-pointer rounded"
             {...register('remember')}
           />
-          <label htmlFor="remember" className="text-brand-gray-500 text-sm">
+          <label
+            htmlFor="remember"
+            className="text-brand-gray-500 cursor-pointer text-sm select-none"
+          >
             이메일 저장
           </label>
         </div>
@@ -200,10 +243,10 @@ export default function LoginForm() {
           variant="secondary"
           disabled={isDisabled}
           className={`w-full font-normal hover:opacity-90 ${
-            !isDisabled ? 'cursor-pointer' : ''
+            !isDisabled ? 'cursor-pointer' : 'cursor-not-allowed'
           }`}
         >
-          이메일로 로그인
+          {isSubmitting ? '로그인 중...' : '이메일로 로그인'}
         </Button>
       </form>
 

--- a/src/features/auth/login/ui/LoginForm.tsx
+++ b/src/features/auth/login/ui/LoginForm.tsx
@@ -139,6 +139,7 @@ export default function LoginForm() {
 
         const redirectPath = next ? decodeURIComponent(next) : '/'
         router.replace(redirectPath)
+        router.refresh()
       } catch (error) {
         const axiosError = error as AxiosError
         const errorData = axiosError.response?.data

--- a/src/features/auth/login/ui/LoginForm.tsx
+++ b/src/features/auth/login/ui/LoginForm.tsx
@@ -16,17 +16,13 @@ import { setAccessToken } from '@/features/auth'
 import { postEmailLogin } from '@/features/auth/api/endpoints/login'
 import {
   EmailLoginRequest,
-  TokenResponse,
+  EmailLoginResponse,
+  LoginInvalidCredentialsErrorSchema,
+  LoginAccountWithdrawnErrorSchema,
+  LoginBlockedErrorSchema,
 } from '@/features/auth/api/schemas/login'
 
 const SAVED_EMAIL_KEY = 'studigo.saved_login_email'
-
-const ErrorResponseSchema = z.object({
-  error_code: z.string(),
-  error_detail: z.string(),
-  retry_after: z.number().optional(),
-})
-type ErrorResponse = z.infer<typeof ErrorResponseSchema>
 
 const loginFormSchema = z
   .object({
@@ -99,7 +95,6 @@ export default function LoginForm() {
   useEffect(() => {
     const raw = localStorage.getItem(SAVED_EMAIL_KEY)
     if (!raw) return
-
     try {
       const parsed: { email: string; remember: boolean } = JSON.parse(raw)
       if (parsed.remember) {
@@ -134,48 +129,36 @@ export default function LoginForm() {
       }
 
       try {
-        const response: TokenResponse = await postEmailLogin(payload)
+        const response = (await postEmailLogin(payload)) as EmailLoginResponse
 
         if (response.accessToken) {
           setAccessToken(response.accessToken)
         }
 
-        toast.success('로그인에 성공했습니다.')
+        toast.success(`${response.user.nickname}님, 환영합니다!`)
 
         const redirectPath = next ? decodeURIComponent(next) : '/'
         router.replace(redirectPath)
       } catch (error) {
-        const axiosError = error as AxiosError<unknown>
-        const parsedError = ErrorResponseSchema.safeParse(
-          axiosError.response?.data
-        )
+        const axiosError = error as AxiosError
+        const errorData = axiosError.response?.data
 
-        if (!parsedError.success) {
-          toast.error('로그인 중 알 수 없는 오류가 발생했습니다.')
-          return
-        }
+        const invalid = LoginInvalidCredentialsErrorSchema.safeParse(errorData)
+        if (invalid.success) return toast.error(invalid.data.detail)
 
-        const err: ErrorResponse = parsedError.data
+        const blocked = LoginBlockedErrorSchema.safeParse(errorData)
+        if (blocked.success)
+          return toast.error(
+            `${blocked.data.error_detail} (대기: ${blocked.data.retry_after}초)`
+          )
 
-        switch (err.error_code) {
-          case 'INVALID_CREDENTIALS':
-            toast.error('이메일 또는 비밀번호를 확인해주세요.')
-            break
-          case 'ACCOUNT_WITHDRAWN':
-            toast.error('탈퇴한 계정입니다.')
-            break
-          case 'ACCOUNT_BANNED':
-            toast.error('이용이 제한된 계정입니다.')
-            break
-          case 'LOGIN_BLOCKED':
-            toast.error(
-              err.error_detail ||
-                '로그인 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요.'
-            )
-            break
-          default:
-            toast.error(err.error_detail || '로그인에 실패했습니다.')
-        }
+        const withdrawn = LoginAccountWithdrawnErrorSchema.safeParse(errorData)
+        if (withdrawn.success)
+          return toast.error(
+            `${withdrawn.data.error_detail} (복구 기한: ${withdrawn.data.restoreDeadline.toLocaleDateString()})`
+          )
+
+        toast.error('로그인 정보가 일치하지 않거나 오류가 발생했습니다.')
       }
     },
     [router, next]
@@ -197,6 +180,7 @@ export default function LoginForm() {
             placeholder="이메일을 입력해주세요."
             autoComplete="email"
             {...register('email')}
+            className={errors.email ? 'border-brand-error' : ''}
           />
           {errors.email?.message && (
             <p className="text-brand-error text-sm">{errors.email.message}</p>
@@ -214,6 +198,7 @@ export default function LoginForm() {
             placeholder="비밀번호를 입력해주세요."
             autoComplete="current-password"
             {...register('password')}
+            className={errors.password ? 'border-brand-error' : ''}
           />
           {errors.password?.message && (
             <p className="text-brand-error text-sm">

--- a/src/features/auth/model/store/token-store.ts
+++ b/src/features/auth/model/store/token-store.ts
@@ -1,0 +1,11 @@
+let accessToken: string | null = null
+
+export const setAccessToken = (token: string) => {
+  accessToken = token
+}
+
+export const getAccessToken = () => accessToken
+
+export const clearAccessToken = () => {
+  accessToken = null
+}

--- a/src/features/auth/model/store/token-store.ts
+++ b/src/features/auth/model/store/token-store.ts
@@ -1,11 +1,33 @@
+const TOKEN_STORAGE_KEY = 'studigo_access_token'
+
 let accessToken: string | null = null
+
+const initializeToken = () => {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem(TOKEN_STORAGE_KEY)
+    if (stored) {
+      accessToken = stored
+    }
+  }
+}
 
 export const setAccessToken = (token: string) => {
   accessToken = token
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(TOKEN_STORAGE_KEY, token)
+  }
 }
 
-export const getAccessToken = () => accessToken
+export const getAccessToken = () => {
+  if (accessToken === null) {
+    initializeToken()
+  }
+  return accessToken
+}
 
 export const clearAccessToken = () => {
   accessToken = null
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(TOKEN_STORAGE_KEY)
+  }
 }

--- a/src/features/auth/model/store/token-store.ts
+++ b/src/features/auth/model/store/token-store.ts
@@ -1,33 +1,34 @@
+import { create } from 'zustand'
+
 const TOKEN_STORAGE_KEY = 'studigo_access_token'
 
-let accessToken: string | null = null
+interface TokenStore {
+  accessToken: string | null
+  setAccessToken: (token: string) => void
+  clearAccessToken: () => void
+  initializeToken: () => void
+}
 
-const initializeToken = () => {
-  if (typeof window !== 'undefined') {
-    const stored = localStorage.getItem(TOKEN_STORAGE_KEY)
-    if (stored) {
-      accessToken = stored
+export const useTokenStore = create<TokenStore>((set) => ({
+  accessToken: null,
+  setAccessToken: (token) => {
+    set({ accessToken: token })
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(TOKEN_STORAGE_KEY, token)
     }
-  }
-}
-
-export const setAccessToken = (token: string) => {
-  accessToken = token
-  if (typeof window !== 'undefined') {
-    localStorage.setItem(TOKEN_STORAGE_KEY, token)
-  }
-}
-
-export const getAccessToken = () => {
-  if (accessToken === null) {
-    initializeToken()
-  }
-  return accessToken
-}
-
-export const clearAccessToken = () => {
-  accessToken = null
-  if (typeof window !== 'undefined') {
-    localStorage.removeItem(TOKEN_STORAGE_KEY)
-  }
-}
+  },
+  clearAccessToken: () => {
+    set({ accessToken: null })
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(TOKEN_STORAGE_KEY)
+    }
+  },
+  initializeToken: () => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem(TOKEN_STORAGE_KEY)
+      if (stored) {
+        set({ accessToken: stored })
+      }
+    }
+  },
+}))

--- a/src/features/auth/ui/HeaderWrapper.tsx
+++ b/src/features/auth/ui/HeaderWrapper.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { getAccessToken } from '@/features/auth'
+import { useTokenStore } from '@/features/auth'
 import Header from '@/shared/ui/header/Header'
 
 export const HeaderWrapper = () => {
-  const token = getAccessToken()
-  const isLoggedIn = !!token
-
+  const accessToken = useTokenStore((state) => state.accessToken)
+  const isLoggedIn = !!accessToken
   return <Header isLoggedIn={isLoggedIn} />
 }

--- a/src/features/auth/ui/HeaderWrapper.tsx
+++ b/src/features/auth/ui/HeaderWrapper.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { getAccessToken } from '@/features/auth'
+import Header from '@/shared/ui/header/Header'
+
+export const HeaderWrapper = () => {
+  const token = getAccessToken()
+  const isLoggedIn = !!token
+
+  return <Header isLoggedIn={isLoggedIn} />
+}

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -5,4 +5,5 @@ export const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true,
 })

--- a/src/shared/api/mocks/handlers/auth-handlers.ts
+++ b/src/shared/api/mocks/handlers/auth-handlers.ts
@@ -1,27 +1,30 @@
 import { http, HttpResponse } from 'msw'
 
-interface EmailLoginRequestBody {
+interface LoginRequestBody {
   email: string
   password: string
-  remember_me?: boolean
 }
 
-// 이메일
 export const authHandlers = [
   http.post(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/login`,
     async ({ request }) => {
-      const body = (await request.json()) as EmailLoginRequestBody
+      const body = (await request.json()) as LoginRequestBody
 
-      if (body.password === 'studigo10!') {
+      if (body.password === 'stydigo10!') {
         return HttpResponse.json({
-          access_token: 'MOCK_ACCESS_TOKEN_FOR_EMAIL',
+          access_token: 'MOCK_ACCESS_TOKEN_STYDIGO',
           token_type: 'Bearer',
           expires_in: 3600,
           user: {
-            id: 1,
+            id: 12345,
             email: body.email,
-            nickname: '스터디고고',
+            nickname: '스터디고유저',
+            name: '홍길동',
+            profile_image_url: 'https://picsum.photos/200',
+            role: 'USER',
+            status: 'ACTIVE',
+            provider: 'EMAIL',
           },
         })
       }
@@ -30,9 +33,11 @@ export const authHandlers = [
         return HttpResponse.json(
           {
             error_code: 'LOGIN_BLOCKED',
-            error_detail: '5회 이상 실패하여 30분간 로그인이 제한됩니다.',
+            error_detail:
+              '로그인 시도 횟수를 초과했습니다. 10분 후 다시 시도해주세요.',
+            retry_after: 600,
           },
-          { status: 403 }
+          { status: 429 }
         )
       }
 
@@ -40,17 +45,9 @@ export const authHandlers = [
         return HttpResponse.json(
           {
             error_code: 'ACCOUNT_WITHDRAWN',
-            error_detail: '이미 탈퇴 처리된 계정입니다.',
-          },
-          { status: 403 }
-        )
-      }
-
-      if (body.password === 'banned10!') {
-        return HttpResponse.json(
-          {
-            error_code: 'ACCOUNT_BANNED',
-            error_detail: '이용이 제한된 계정입니다.',
+            error_detail: '탈퇴한 계정입니다.',
+            can_restore: true,
+            restore_deadline: '2026-02-08T10:30:00Z',
           },
           { status: 403 }
         )
@@ -58,50 +55,36 @@ export const authHandlers = [
 
       return HttpResponse.json(
         {
-          error_code: 'INVALID_CREDENTIALS',
-          error_detail: '이메일 또는 비밀번호가 일치하지 않습니다.',
+          detail: '이메일 또는 비밀번호를 확인해주세요.',
         },
         { status: 401 }
       )
     }
   ),
 
-  // 카카오
-  http.post(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/oauth/kakao`,
-    async ({ request }) => {
-      const body = (await request.json()) as {
-        authorization_code: string
-        redirect_uri: string
-      }
+  http.post(`${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/oauth/kakao`, () => {
+    return HttpResponse.json({
+      access_token: 'MOCK_KAKAO_TOKEN',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      user: {
+        id: 54321,
+        email: 'kakao@example.com',
+        nickname: '카카오유저',
+        name: '김카카오',
+        profile_image_url: null,
+        role: 'USER',
+        status: 'ACTIVE',
+        provider: 'KAKAO',
+      },
+    })
+  }),
 
-      // 신규 회원
-      if (body.authorization_code === 'NEW_USER') {
-        return HttpResponse.json({
-          is_new_user: true,
-          requires_additional_info: true,
-          temporary_token: 'TEMP_TOKEN_KAKAO_123',
-          kakao_user_info: {
-            email: 'kakao_user@kakao.com',
-            nickname: 'kakao_newbie',
-            profile_image_url: null,
-          },
-          missing_fields: ['phone', 'birthdate'],
-        })
-      }
-
-      // 기존 회원
-      return HttpResponse.json({
-        is_new_user: false,
-        access_token: 'ACCESS_TOKEN_MOCK_KAKAO',
-        token_type: 'Bearer',
-        expires_in: 3600,
-        user: {
-          id: 2,
-          email: 'kakao_user@kakao.com',
-          nickname: '카카오친구',
-        },
-      })
-    }
-  ),
+  http.post(`${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/refresh`, () => {
+    return HttpResponse.json({
+      access_token: 'REFRESHED_MOCK_TOKEN',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    })
+  }),
 ]

--- a/src/shared/api/mocks/handlers/auth-handlers.ts
+++ b/src/shared/api/mocks/handlers/auth-handlers.ts
@@ -13,7 +13,7 @@ export const authHandlers = [
     async ({ request }) => {
       const body = (await request.json()) as EmailLoginRequestBody
 
-      if (body.password === 'studigo123!') {
+      if (body.password === 'studigo10!') {
         return HttpResponse.json({
           access_token: 'MOCK_ACCESS_TOKEN_FOR_EMAIL',
           token_type: 'Bearer',
@@ -26,7 +26,7 @@ export const authHandlers = [
         })
       }
 
-      if (body.password === 'blocked123!') {
+      if (body.password === 'blocked10!') {
         return HttpResponse.json(
           {
             error_code: 'LOGIN_BLOCKED',
@@ -36,7 +36,7 @@ export const authHandlers = [
         )
       }
 
-      if (body.password === 'withdrawn123!') {
+      if (body.password === 'withdrawn10!') {
         return HttpResponse.json(
           {
             error_code: 'ACCOUNT_WITHDRAWN',
@@ -46,7 +46,7 @@ export const authHandlers = [
         )
       }
 
-      if (body.password === 'banned123!') {
+      if (body.password === 'banned10!') {
         return HttpResponse.json(
           {
             error_code: 'ACCOUNT_BANNED',

--- a/src/shared/api/mocks/handlers/auth-handlers.ts
+++ b/src/shared/api/mocks/handlers/auth-handlers.ts
@@ -1,6 +1,72 @@
 import { http, HttpResponse } from 'msw'
 
+interface EmailLoginRequestBody {
+  email: string
+  password: string
+  remember_me?: boolean
+}
+
+// 이메일
 export const authHandlers = [
+  http.post(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/login`,
+    async ({ request }) => {
+      const body = (await request.json()) as EmailLoginRequestBody
+
+      if (body.password === 'studigo123!') {
+        return HttpResponse.json({
+          access_token: 'MOCK_ACCESS_TOKEN_FOR_EMAIL',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          user: {
+            id: 1,
+            email: body.email,
+            nickname: '스터디고고',
+          },
+        })
+      }
+
+      if (body.password === 'blocked123!') {
+        return HttpResponse.json(
+          {
+            error_code: 'LOGIN_BLOCKED',
+            error_detail: '5회 이상 실패하여 30분간 로그인이 제한됩니다.',
+          },
+          { status: 403 }
+        )
+      }
+
+      if (body.password === 'withdrawn123!') {
+        return HttpResponse.json(
+          {
+            error_code: 'ACCOUNT_WITHDRAWN',
+            error_detail: '이미 탈퇴 처리된 계정입니다.',
+          },
+          { status: 403 }
+        )
+      }
+
+      if (body.password === 'banned123!') {
+        return HttpResponse.json(
+          {
+            error_code: 'ACCOUNT_BANNED',
+            error_detail: '이용이 제한된 계정입니다.',
+          },
+          { status: 403 }
+        )
+      }
+
+      return HttpResponse.json(
+        {
+          error_code: 'INVALID_CREDENTIALS',
+          error_detail: '이메일 또는 비밀번호가 일치하지 않습니다.',
+        },
+        { status: 401 }
+      )
+    }
+  ),
+
+  // 카카오
   http.post(
     `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/oauth/kakao`,
     async ({ request }) => {
@@ -9,34 +75,31 @@ export const authHandlers = [
         redirect_uri: string
       }
 
-      // 신규회원
+      // 신규 회원
       if (body.authorization_code === 'NEW_USER') {
         return HttpResponse.json({
           is_new_user: true,
           requires_additional_info: true,
-          temporary_token: 'TEMP_TOKEN_123',
+          temporary_token: 'TEMP_TOKEN_KAKAO_123',
           kakao_user_info: {
             email: 'kakao_user@kakao.com',
-            nickname: 'kakao_Ab3Cd5',
-            profile_image_url: 'blank',
+            nickname: 'kakao_newbie',
+            profile_image_url: null,
           },
-          missing_fields: ['phone', 'birthdate', 'gender'],
+          missing_fields: ['phone', 'birthdate'],
         })
       }
 
-      // 기존회원
+      // 기존 회원
       return HttpResponse.json({
         is_new_user: false,
-        access_token: 'ACCESS_TOKEN_MOCK',
-        refresh_token: 'REFRESH_TOKEN_MOCK',
+        access_token: 'ACCESS_TOKEN_MOCK_KAKAO',
         token_type: 'Bearer',
         expires_in: 3600,
         user: {
-          id: 1,
+          id: 2,
           email: 'kakao_user@kakao.com',
-          nickname: '카카오유저',
-          profile_image_url: 'https://...',
-          role: 'USER',
+          nickname: '카카오친구',
         },
       })
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #54 

## 📝작업 내용
> 이메일 로그인 기능 구현
> localStorage에 Access Token 저장하여 새로고침 후에도 유지
> 로그인 여부에 따라 헤더 UI 동적 변경
> API 엔드포인트 경로 정규화

-  로그인 하실 때 아이디(이메일)은 아무거나 적어도 상관이 없습니다.
테스트 용 비밀번호는 아래와 같습니다.
   - 비밀번호: `stydigo10!` → 로그인 성공
   - 비밀번호: `blocked10!` → 로그인 차단
   - 비밀번호: `withdrawn10!` → 탈퇴한 계정
   - 비밀번호 : 위의 3개 제외한 나머지 → 비밀번호가 일치하지않습니다
- 비밀번호만 맞게 잘 작성해주시면 됩니다.

- 로그아웃은 아직 구현이 되지 않았기에 로그아웃을 하고 싶으시면 개발자 도구 들어가서 Application에서 Local storage안에 http://localhost:3000 들어가신 뒤 studigo_access_token을 지워주시면 됩니다. 
그 뒤 새로고침 하시면 로그아웃이 됩니다.

## 🖼️스크린샷

> 

https://github.com/user-attachments/assets/f778ab6f-1b39-46e5-b827-2a7ac0fa99ff

<img width="1674" height="972" alt="스크린샷 2026-01-25 오후 9 44 48" src="https://github.com/user-attachments/assets/9485391f-f9b5-4d6e-b40e-964036fb1d3a" />
마지막 로그인 완료 후 메인페이지 헤더 드롭다운

## 💬리뷰 요구사항 (선택)

>

## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
