### PR TITLE
[Feature] 채팅방 입장, 채팅 메세지 조회 API 연동

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react'
 
 function Chat() {
   return (
-    <div className="mt-14 mb-24.5">
+    <div className="mt-14 mb-35.5">
       <section className="relative mb-12.5 aspect-8/1">
         <Image
           src="/images/chat/chat-banner.webp"
@@ -22,7 +22,7 @@ function Chat() {
             <div className="h-96 w-full animate-pulse rounded-xl bg-gray-50"></div>
           }
         >
-          <div className="border-b-brand-gray-100 mt-8 mb-14 border-b">
+          <div className="border-b-brand-gray-100 mt-8 mb-4 border-b">
             <div className="flex items-end justify-between">
               <div className="text-brand-black relative pb-4 text-lg font-bold">
                 <span>전체</span>

--- a/src/features/chat/api/api.ts
+++ b/src/features/chat/api/api.ts
@@ -1,11 +1,20 @@
 import { api } from '@/shared/api/client'
 import {
-  ChatRoomListResponse,
   ChatRoomListResponseSchema,
+  type ChatRoomListResponse,
+  type ChatRoomEnterResponse,
 } from '@/features/chat/model/schema'
 
 // ---------- 채팅방 목록 조회 ----------
 export const getChatRoomList = async (): Promise<ChatRoomListResponse> => {
   const response = await api.get('/chat')
   return ChatRoomListResponseSchema.parse(response.data)
+}
+
+// ---------- 채팅방 입장 ----------
+export const enterChatRoom = async (
+  roomId: number
+): Promise<ChatRoomEnterResponse> => {
+  const response = await api.post(`/chat/${roomId}`)
+  return response.data
 }

--- a/src/features/chat/api/api.ts
+++ b/src/features/chat/api/api.ts
@@ -1,8 +1,11 @@
 import { api } from '@/shared/api/client'
 import {
   ChatRoomListResponseSchema,
+  ChatMessageListResponseSchema,
   type ChatRoomListResponse,
   type ChatRoomEnterResponse,
+  type ChatMessageListResponse,
+  type ChatMessageListRequest,
 } from '@/features/chat/model/schema'
 
 // ---------- 채팅방 목록 조회 ----------
@@ -17,4 +20,16 @@ export const enterChatRoom = async (
 ): Promise<ChatRoomEnterResponse> => {
   const response = await api.post(`/chat/${roomId}`)
   return response.data
+}
+
+// ---------- 채팅 메세지 조회 ----------
+export const getChatMessageList = async ({
+  roomId,
+  size = 20,
+  cursor,
+}: ChatMessageListRequest): Promise<ChatMessageListResponse> => {
+  const response = await api.get(`/chat/${roomId}/messages`, {
+    params: { cursor, size },
+  })
+  return ChatMessageListResponseSchema.parse(response.data)
 }

--- a/src/features/chat/api/queries.ts
+++ b/src/features/chat/api/queries.ts
@@ -1,12 +1,15 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
-import { type ChatRoomListResponse } from '@/features/chat/model/schema'
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+import {
+  type ChatRoomListResponse,
+  type ChatErrorResponse,
+} from '@/features/chat/model/schema'
 import { queryKeys } from '@/features/chat/api/query-keys'
 import { getChatRoomList } from '@/features/chat/api/api'
 import { AxiosError } from 'axios'
 
 // ---------- 채팅방 목록 조회 ----------
 type ChatRoomListQueryOptions = Omit<
-  UseQueryOptions<ChatRoomListResponse, AxiosError>,
+  UseQueryOptions<ChatRoomListResponse, AxiosError<ChatErrorResponse>>,
   'queryKey' | 'queryFn'
 >
 

--- a/src/features/chat/api/queries.ts
+++ b/src/features/chat/api/queries.ts
@@ -1,16 +1,24 @@
 import {
   useQuery,
   useMutation,
+  useInfiniteQuery,
   type UseQueryOptions,
   type UseMutationOptions,
+  type UseInfiniteQueryOptions,
+  type InfiniteData,
 } from '@tanstack/react-query'
 import {
   type ChatRoomListResponse,
   type ChatRoomEnterResponse,
   type ChatErrorResponse,
+  type ChatMessageListResponse,
 } from '@/features/chat/model/schema'
 import { queryKeys } from '@/features/chat/api/query-keys'
-import { enterChatRoom, getChatRoomList } from '@/features/chat/api/api'
+import {
+  enterChatRoom,
+  getChatMessageList,
+  getChatRoomList,
+} from '@/features/chat/api/api'
 import { AxiosError } from 'axios'
 import { useChatStore } from '@/features/chat/model/store'
 import { toast } from 'sonner'
@@ -54,6 +62,35 @@ export const useEnterChatRoom = (options?: EnterChatRoomMutationOptions) => {
     onError: (error) => {
       toast.error(error.response?.data.detail ?? '채팅방 입장에 실패했습니다.')
     },
+    ...options,
+  })
+}
+
+// ---------- 채팅 메세지 조회 ----------
+type ChatMessageListQueryOptions = Omit<
+  UseInfiniteQueryOptions<
+    ChatMessageListResponse,
+    AxiosError<ChatErrorResponse>,
+    InfiniteData<ChatMessageListResponse>
+  >,
+  'queryKey' | 'queryFn' | 'initialPageParam' | 'getNextPageParam' | 'enabled'
+>
+
+export const useChatMessageList = (
+  roomId: number | null,
+  options?: ChatMessageListQueryOptions
+) => {
+  return useInfiniteQuery({
+    queryKey: queryKeys.messageList(roomId ?? -1),
+    queryFn: ({ pageParam }) =>
+      getChatMessageList({
+        roomId: roomId ?? -1,
+        cursor: pageParam as number | undefined,
+      }),
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore ? lastPage.nextCursor : undefined,
+    enabled: !!roomId,
     ...options,
   })
 }

--- a/src/features/chat/api/queries.ts
+++ b/src/features/chat/api/queries.ts
@@ -1,11 +1,20 @@
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+import {
+  useQuery,
+  useMutation,
+  type UseQueryOptions,
+  type UseMutationOptions,
+} from '@tanstack/react-query'
 import {
   type ChatRoomListResponse,
+  type ChatRoomEnterResponse,
   type ChatErrorResponse,
 } from '@/features/chat/model/schema'
 import { queryKeys } from '@/features/chat/api/query-keys'
-import { getChatRoomList } from '@/features/chat/api/api'
+import { enterChatRoom, getChatRoomList } from '@/features/chat/api/api'
 import { AxiosError } from 'axios'
+import { useChatStore } from '@/features/chat/model/store'
+import { toast } from 'sonner'
+import { useRouter } from 'next/navigation'
 
 // ---------- 채팅방 목록 조회 ----------
 type ChatRoomListQueryOptions = Omit<
@@ -17,6 +26,34 @@ export const useChatRoomList = (options?: ChatRoomListQueryOptions) => {
   return useQuery({
     queryKey: queryKeys.roomList(),
     queryFn: getChatRoomList,
+    ...options,
+  })
+}
+
+// ---------- 채팅방 입장 ----------
+type EnterChatRoomMutationOptions = Omit<
+  UseMutationOptions<
+    ChatRoomEnterResponse,
+    AxiosError<ChatErrorResponse>,
+    number
+  >,
+  'mutationFn' | 'onSuccess' | 'onError'
+>
+
+export const useEnterChatRoom = (options?: EnterChatRoomMutationOptions) => {
+  const setEnteredRoomId = useChatStore((state) => state.setEnteredRoomId)
+  const router = useRouter()
+
+  return useMutation({
+    mutationFn: enterChatRoom,
+    onSuccess: (data) => {
+      const roomId = data.room.id
+      setEnteredRoomId(roomId)
+      router.push(`/chat/${roomId}`)
+    },
+    onError: (error) => {
+      toast.error(error.response?.data.detail ?? '채팅방 입장에 실패했습니다.')
+    },
     ...options,
   })
 }

--- a/src/features/chat/api/query-keys.ts
+++ b/src/features/chat/api/query-keys.ts
@@ -1,4 +1,6 @@
 export const queryKeys = {
   all: ['chat'] as const,
   roomList: () => [...queryKeys.all, 'rooms', 'list'] as const,
+  messageList: (roomId: number) =>
+    [...queryKeys.all, roomId, 'message', 'list'] as const,
 }

--- a/src/features/chat/model/schema.ts
+++ b/src/features/chat/model/schema.ts
@@ -1,33 +1,35 @@
 import z from 'zod'
 
 // ---------- 채팅방 목록 조회 ----------
-export const ChatRoomSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  description: z.string(),
-  participant_count: z.number(),
-  last_message_at: z.coerce.date(),
-  created_at: z.coerce.date(),
-})
+export const ChatRoomSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+    description: z.string(),
+    participant_count: z.number(),
+    last_message_at: z.coerce.date(),
+    created_at: z.coerce.date(),
+  })
+  .transform((data) => ({
+    id: data.id,
+    name: data.name,
+    description: data.description,
+    participantCount: data.participant_count,
+    lastMessageAt: data.last_message_at,
+    createdAt: data.created_at,
+  }))
+
+export type ChatRoom = z.infer<typeof ChatRoomSchema>
 
 export const ChatRoomListResponseSchema = z
   .object({
     rooms: z.array(ChatRoomSchema),
   })
   .transform((data) => ({
-    rooms: data.rooms.map((room) => ({
-      id: room.id,
-      name: room.name,
-      description: room.description,
-      participantCount: room.participant_count,
-      lastMessageAt: room.last_message_at,
-      createdAt: room.created_at,
-    })),
+    rooms: data.rooms,
   }))
 
 export type ChatRoomListResponse = z.infer<typeof ChatRoomListResponseSchema>
-
-export type ChatRoom = ChatRoomListResponse['rooms'][0]
 
 // ---------- 채팅방 입장 ----------
 export const ChatRoomEnterResponseSchema = z.object({
@@ -51,20 +53,39 @@ export type ChatMessageListRequest = z.infer<
   typeof ChatMessageListRequestSchema
 >
 
-export const ChatMessageSenderSchema = z.object({
-  id: z.number(),
-  nickname: z.string(),
-  profile_image_url: z.nullable(z.string()),
-})
+export const ChatMessageSenderSchema = z
+  .object({
+    id: z.number(),
+    nickname: z.string(),
+    profile_image_url: z.nullable(z.string()),
+  })
+  .transform((data) => ({
+    id: data.id,
+    nickname: data.nickname,
+    profileImageUrl: data.profile_image_url,
+  }))
 
-export const ChatMessageSchema = z.object({
-  id: z.number(),
-  sender_user_id: z.number(),
-  sender: ChatMessageSenderSchema,
-  content: z.string(),
-  status: z.enum(['SENT', 'DELETED_BY_ADMIN']),
-  created_at: z.coerce.date(),
-})
+export type MessageSender = z.infer<typeof ChatMessageSenderSchema>
+
+export const ChatMessageSchema = z
+  .object({
+    id: z.number(),
+    sender_user_id: z.number(),
+    sender: ChatMessageSenderSchema,
+    content: z.string(),
+    status: z.enum(['SENT', 'DELETED_BY_ADMIN']),
+    created_at: z.coerce.date(),
+  })
+  .transform((data) => ({
+    id: data.id,
+    senderUserId: data.sender_user_id,
+    sender: data.sender,
+    content: data.content,
+    status: data.status,
+    createdAt: data.created_at,
+  }))
+
+export type Message = z.infer<typeof ChatMessageSchema>
 
 export const ChatMessageListResponseSchema = z
   .object({
@@ -75,18 +96,7 @@ export const ChatMessageListResponseSchema = z
   })
   .transform((data) => ({
     roomId: data.room_id,
-    messages: data.messages.map((message) => ({
-      id: message.id,
-      senderUserId: message.sender_user_id,
-      sender: {
-        id: message.sender.id,
-        nickname: message.sender.nickname,
-        profileImageUrl: message.sender.profile_image_url,
-      },
-      content: message.content,
-      status: message.status,
-      createdAt: message.created_at,
-    })),
+    messages: data.messages,
     nextCursor: data.next_cursor,
     hasMore: data.has_more,
   }))
@@ -94,8 +104,6 @@ export const ChatMessageListResponseSchema = z
 export type ChatMessageListResponse = z.infer<
   typeof ChatMessageListResponseSchema
 >
-
-export type Message = ChatMessageListResponse['messages'][0]
 
 // ---------- 실패 ----------
 export const ChatErrorResponseSchema = z.object({

--- a/src/features/chat/model/schema.ts
+++ b/src/features/chat/model/schema.ts
@@ -40,6 +40,63 @@ export const ChatRoomEnterResponseSchema = z.object({
 
 export type ChatRoomEnterResponse = z.infer<typeof ChatRoomEnterResponseSchema>
 
+// ---------- 채팅 메세지 조회 ----------
+export const ChatMessageListRequestSchema = z.object({
+  roomId: z.number(),
+  size: z.number().optional(),
+  cursor: z.number().optional(),
+})
+
+export type ChatMessageListRequest = z.infer<
+  typeof ChatMessageListRequestSchema
+>
+
+export const ChatMessageSenderSchema = z.object({
+  id: z.number(),
+  nickname: z.string(),
+  profile_image_url: z.nullable(z.string()),
+})
+
+export const ChatMessageSchema = z.object({
+  id: z.number(),
+  sender_user_id: z.number(),
+  sender: ChatMessageSenderSchema,
+  content: z.string(),
+  status: z.enum(['SENT', 'DELETED_BY_ADMIN']),
+  created_at: z.coerce.date(),
+})
+
+export const ChatMessageListResponseSchema = z
+  .object({
+    room_id: z.number(),
+    messages: z.array(ChatMessageSchema),
+    next_cursor: z.nullable(z.number()),
+    has_more: z.boolean(),
+  })
+  .transform((data) => ({
+    roomId: data.room_id,
+    messages: data.messages.map((message) => ({
+      id: message.id,
+      senderUserId: message.sender_user_id,
+      sender: {
+        id: message.sender.id,
+        nickname: message.sender.nickname,
+        profileImageUrl: message.sender.profile_image_url,
+      },
+      content: message.content,
+      status: message.status,
+      createdAt: message.created_at,
+    })),
+    nextCursor: data.next_cursor,
+    hasMore: data.has_more,
+  }))
+
+export type ChatMessageListResponse = z.infer<
+  typeof ChatMessageListResponseSchema
+>
+
+export type Message = ChatMessageListResponse['messages'][0]
+
 // ---------- 실패 ----------
 export const ChatErrorResponseSchema = z.object({
   detail: z.string(),

--- a/src/features/chat/model/schema.ts
+++ b/src/features/chat/model/schema.ts
@@ -39,3 +39,10 @@ export const ChatRoomEnterResponseSchema = z.object({
 })
 
 export type ChatRoomEnterResponse = z.infer<typeof ChatRoomEnterResponseSchema>
+
+// ---------- 실패 ----------
+export const ChatErrorResponseSchema = z.object({
+  detail: z.string(),
+})
+
+export type ChatErrorResponse = z.infer<typeof ChatErrorResponseSchema>

--- a/src/features/chat/model/schema.ts
+++ b/src/features/chat/model/schema.ts
@@ -28,3 +28,14 @@ export const ChatRoomListResponseSchema = z
 export type ChatRoomListResponse = z.infer<typeof ChatRoomListResponseSchema>
 
 export type ChatRoom = ChatRoomListResponse['rooms'][0]
+
+// ---------- 채팅방 입장 ----------
+export const ChatRoomEnterResponseSchema = z.object({
+  message: z.string(),
+  room: z.object({
+    id: z.number(),
+    name: z.string(),
+  }),
+})
+
+export type ChatRoomEnterResponse = z.infer<typeof ChatRoomEnterResponseSchema>

--- a/src/features/chat/model/store.ts
+++ b/src/features/chat/model/store.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface ChatStore {
+  enteredRoomId: number | null
+  setEnteredRoomId: (roomId: number) => void
+  clearEnteredRoomId: () => void
+}
+
+const useChatStore = create<ChatStore>()(
+  persist(
+    (set) => ({
+      enteredRoomId: null,
+      setEnteredRoomId: (roomId) => set({ enteredRoomId: roomId }),
+      clearEnteredRoomId: () => set({ enteredRoomId: null }),
+    }),
+    { name: 'chat-storage' }
+  )
+)
+
+export { useChatStore }

--- a/src/features/chat/ui/ChatHeader.tsx
+++ b/src/features/chat/ui/ChatHeader.tsx
@@ -1,12 +1,14 @@
-import { CHAT_ROOMS } from '@/shared/api/mocks/data/chat-data'
+'use client'
+
 import { EllipsisVerticalIcon, UserIcon } from 'lucide-react'
 import Image from 'next/image'
+import { useChatStore } from '@/features/chat/model/store'
+import { useChatRoomList } from '@/features/chat/api/queries'
 
 function ChatHeader() {
-  // TODO: 채팅방 리스트 정보 스토어에 저장하고 불러오기
-  const chatRooms = CHAT_ROOMS
-  const currentRoomId = 2
-  const currentRoom = chatRooms.find((room) => room.id === currentRoomId)
+  const currentRoomId = useChatStore((state) => state.enteredRoomId)
+  const { data } = useChatRoomList()
+  const currentRoom = data?.rooms.find((room) => room.id === currentRoomId)
 
   return (
     <div className="border-b-brand-gray-200 flex max-w-239 items-center border-b py-2.5">
@@ -23,8 +25,7 @@ function ChatHeader() {
         <span className="mb-1 text-4xl font-medium">{currentRoom?.name}</span>
         <div className="text-brand-gray-300 flex items-center gap-1 text-xl font-semibold">
           <UserIcon size={20} strokeWidth={2.8} />
-          {/* TODO: 채팅방 리스트 정보 스토어에 저장하고 불러오면 필드 이름 수정하기 */}
-          <span>{currentRoom?.participant_count} 참여중</span>
+          <span>{currentRoom?.participantCount} 참여중</span>
         </div>
       </div>
       {/* TODO: 채팅방 퇴장 API 연결할 때 클릭하면 메뉴 나오게 만들기 */}

--- a/src/features/chat/ui/ChatRoomItem.tsx
+++ b/src/features/chat/ui/ChatRoomItem.tsx
@@ -15,7 +15,8 @@ function ChatRoomItem({ chatRoom }: ChatRoomItemProps) {
   const { mutate: enterChatRoom, isPending } = useEnterChatRoom()
 
   const handleClick = () => {
-    /* TODO: 로그인 안 한 유저는 진입 불가 토스트 보여주기 */
+    /* TODO: 로그인 안 한 유저는 입장 불가 토스트 보여주기 */
+    /* TODO: 이미 접속한 채팅방이 있는 유저는 중복 입장 불가 토스트 보여주기 */
     if (isPending) return
     enterChatRoom(chatRoom.id)
   }
@@ -25,7 +26,7 @@ function ChatRoomItem({ chatRoom }: ChatRoomItemProps) {
       <button
         type="button"
         className={cn(
-          'rounded-brand-base flex w-full min-w-0 items-center',
+          'rounded-brand-base flex w-full min-w-0 items-center py-10',
           'focus:outline-none',
           'hover:bg-brand-light focus-visible:bg-brand-light'
         )}

--- a/src/features/chat/ui/ChatRoomItem.tsx
+++ b/src/features/chat/ui/ChatRoomItem.tsx
@@ -6,19 +6,25 @@ import { formatRelativeDateTime } from '@/features/chat/lib/formatter'
 import { type ChatRoom } from '@/features/chat/model/schema'
 import { useEnterChatRoom } from '@/features/chat/api/queries'
 import { cn } from '@/shared/lib/cn'
+import { useChatStore } from '@/features/chat/model/store'
+import { toast } from 'sonner'
 
 interface ChatRoomItemProps {
   chatRoom: ChatRoom
 }
 
 function ChatRoomItem({ chatRoom }: ChatRoomItemProps) {
+  const enteredRoomId = useChatStore((state) => state.enteredRoomId)
   const { mutate: enterChatRoom, isPending } = useEnterChatRoom()
 
   const handleClick = () => {
     /* TODO: 로그인 안 한 유저는 입장 불가 토스트 보여주기 */
-    /* TODO: 이미 접속한 채팅방이 있는 유저는 중복 입장 불가 토스트 보여주기 */
     if (isPending) return
-    enterChatRoom(chatRoom.id)
+    if (enteredRoomId && enteredRoomId !== chatRoom.id) {
+      toast.warning('채팅방은 중복 입장할 수 없습니다.')
+      return
+    }
+    enterChatRoom(enteredRoomId ?? chatRoom.id)
   }
 
   return (

--- a/src/features/chat/ui/ChatRoomItem.tsx
+++ b/src/features/chat/ui/ChatRoomItem.tsx
@@ -1,38 +1,60 @@
+'use client'
+
 import { UserIcon } from 'lucide-react'
 import Image from 'next/image'
 import { formatRelativeDateTime } from '@/features/chat/lib/formatter'
 import { type ChatRoom } from '@/features/chat/model/schema'
+import { useEnterChatRoom } from '@/features/chat/api/queries'
+import { cn } from '@/shared/lib/cn'
 
 interface ChatRoomItemProps {
   chatRoom: ChatRoom
 }
 
 function ChatRoomItem({ chatRoom }: ChatRoomItemProps) {
-  /* TODO: KJH 로그인 안 한 유저는 진입 불가 토스트 보여주기 */
+  const { mutate: enterChatRoom, isPending } = useEnterChatRoom()
+
+  const handleClick = () => {
+    /* TODO: 로그인 안 한 유저는 진입 불가 토스트 보여주기 */
+    if (isPending) return
+    enterChatRoom(chatRoom.id)
+  }
+
   return (
-    <li className="flex items-center">
-      <div className="relative mr-4 size-25">
-        <Image
-          src={`/images/chat/chat-room-thumbnail-${chatRoom.id}.webp`}
-          alt={`${chatRoom.name} 채팅방 썸네일`}
-          className="object-cover"
-          fill
-          sizes="100px"
-        />
-      </div>
-      <div className="grid flex-1">
-        <span className="mb-2.5 text-xl font-bold">{chatRoom.name}</span>
-        <span className="text-brand-gray-400 mb-2 min-w-0 overflow-hidden text-base text-ellipsis whitespace-nowrap">
-          {chatRoom.description}
-        </span>
-        <div className="text-brand-gray-400 flex items-center gap-1 text-xs font-semibold">
-          <UserIcon size={18} strokeWidth={2.2} />
-          <span>{chatRoom.participantCount} 참여중</span>
+    <li>
+      <button
+        type="button"
+        className={cn(
+          'rounded-brand-base flex w-full min-w-0 items-center',
+          'focus:outline-none',
+          'hover:bg-brand-light focus-visible:bg-brand-light'
+        )}
+        onClick={handleClick}
+        aria-label={`${chatRoom.name} 채팅방에 입장`}
+      >
+        <div className="relative mr-4 size-25 shrink-0">
+          <Image
+            src={`/images/chat/chat-room-thumbnail-${chatRoom.id}.webp`}
+            alt={`${chatRoom.name} 채팅방 썸네일`}
+            className="object-cover"
+            fill
+            sizes="100px"
+          />
         </div>
-      </div>
-      <span className="text-brand-gray-400 ml-4 text-xl font-semibold">
-        {formatRelativeDateTime(chatRoom.lastMessageAt)}
-      </span>
+        <div className="flex min-w-0 flex-1 flex-col items-start">
+          <span className="mb-2.5 text-xl font-bold">{chatRoom.name}</span>
+          <span className="text-brand-gray-400 mb-2 w-full truncate text-start text-base">
+            {chatRoom.description}
+          </span>
+          <div className="text-brand-gray-400 flex items-center gap-1 text-xs font-semibold">
+            <UserIcon size={18} strokeWidth={2.2} />
+            <span>{chatRoom.participantCount} 참여중</span>
+          </div>
+        </div>
+        <span className="text-brand-gray-400 ml-4 text-xl font-semibold">
+          {formatRelativeDateTime(chatRoom.lastMessageAt)}
+        </span>
+      </button>
     </li>
   )
 }

--- a/src/features/chat/ui/ChatRoomList.tsx
+++ b/src/features/chat/ui/ChatRoomList.tsx
@@ -4,6 +4,8 @@ import ChatRoomItem from '@/features/chat/ui/ChatRoomItem'
 import { useSearchParams } from 'next/navigation'
 import { useChatRoomList } from '@/features/chat/api/queries'
 import { type ChatRoom } from '@/features/chat/model/schema'
+import Loading from '@/features/chat/ui/Loading'
+import Error from '@/features/chat/ui/Error'
 
 function ChatRoomList() {
   const { data, isLoading, error } = useChatRoomList()
@@ -12,14 +14,15 @@ function ChatRoomList() {
   const order = searchParams.get('order')
   const orderedChatRooms = getOrderedChatRooms(chatRooms, order)
 
-  if (isLoading)
-    return <div className="animate-pulse py-10 text-center">Loading...</div>
+  if (isLoading) return <Loading />
   if (error)
     return (
-      <div className="text-brand-gray-500 py-10 text-center">
-        {error.response?.data.detail ??
-          '채팅방 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.'}
-      </div>
+      <Error
+        message={
+          error.response?.data.detail ??
+          '채팅방 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.'
+        }
+      />
     )
   return (
     <div>

--- a/src/features/chat/ui/ChatRoomList.tsx
+++ b/src/features/chat/ui/ChatRoomList.tsx
@@ -23,7 +23,7 @@ function ChatRoomList() {
     )
   return (
     <div>
-      <ul className="grid gap-16 py-4">
+      <ul className="grid">
         {orderedChatRooms.map((chatRoom) => (
           <ChatRoomItem key={chatRoom.id} chatRoom={chatRoom} />
         ))}

--- a/src/features/chat/ui/ChatRoomList.tsx
+++ b/src/features/chat/ui/ChatRoomList.tsx
@@ -17,7 +17,8 @@ function ChatRoomList() {
   if (error)
     return (
       <div className="text-brand-gray-500 py-10 text-center">
-        {(error.response?.data as { detail: string })?.detail ?? error.message}
+        {error.response?.data.detail ??
+          '채팅방 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.'}
       </div>
     )
   return (

--- a/src/features/chat/ui/ChatSidebar.tsx
+++ b/src/features/chat/ui/ChatSidebar.tsx
@@ -1,17 +1,20 @@
-import { CHAT_ROOMS } from '@/shared/api/mocks/data/chat-data'
+'use client'
+
 import { cn } from '@/shared/lib/cn'
 import { UserIcon } from 'lucide-react'
 import Image from 'next/image'
+import { useChatRoomList } from '@/features/chat/api/queries'
+import { useChatStore } from '@/features/chat/model/store'
 
 function ChatSidebar() {
-  // TODO: 채팅방 리스트 정보 스토어에 저장하고 불러오기
-  const chatRooms = CHAT_ROOMS
-  const currentRoomId = 2
+  const currentRoomId = useChatStore((state) => state.enteredRoomId)
+  const { data } = useChatRoomList()
+  const chatRooms = data?.rooms
 
   return (
     <aside className="border-brand-gray-200 rounded-brand-base sticky top-20 mb-8 hidden h-max w-61 shrink-0 border py-4 md:block">
       <ul className="grid gap-1">
-        {chatRooms.map((chatRoom) => (
+        {chatRooms?.map((chatRoom) => (
           <li key={chatRoom.id}>
             {/*TODO: 클릭하면 다른 채팅방으로 이동하는 로직 추가*/}
             <button
@@ -51,8 +54,7 @@ function ChatSidebar() {
                   )}
                 >
                   <UserIcon size={14} strokeWidth={2} />
-                  {/* TODO: 채팅방 리스트 정보 스토어에 저장하고 불러오면 필드 이름 수정하기 */}
-                  <span>{chatRoom.participant_count} 참여중</span>
+                  <span>{chatRoom.participantCount} 참여중</span>
                 </div>
               </div>
             </button>

--- a/src/features/chat/ui/Error.tsx
+++ b/src/features/chat/ui/Error.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/shared/lib/cn'
+
+interface ErrorProps {
+  message: string
+  className?: string
+}
+
+function Error({ message, className }: ErrorProps) {
+  return (
+    <div className={cn('text-brand-gray-500 py-10 text-center', className)}>
+      {message}
+    </div>
+  )
+}
+
+export default Error

--- a/src/features/chat/ui/Loading.tsx
+++ b/src/features/chat/ui/Loading.tsx
@@ -1,0 +1,15 @@
+import { cn } from '@/shared/lib/cn'
+
+interface LoadingProps {
+  className?: string
+}
+
+function Loading({ className }: LoadingProps) {
+  return (
+    <div className={cn('animate-pulse py-10 text-center', className)}>
+      Loading...
+    </div>
+  )
+}
+
+export default Loading

--- a/src/features/chat/ui/MessageList.tsx
+++ b/src/features/chat/ui/MessageList.tsx
@@ -1,119 +1,46 @@
+'use client'
+
 import ReceivedMessage from '@/features/chat/ui/ReceivedMessage'
 import SentMessage from '@/features/chat/ui/SentMessage'
+import { useChatMessageList } from '@/features/chat/api/queries'
+import { useChatStore } from '@/features/chat/model/store'
+import { useMemo } from 'react'
+import Loading from '@/features/chat/ui/Loading'
+import Error from '@/features/chat/ui/Error'
 
 // TODO: 유저 정보 스토어에 저장된 것 불러오기
 const userId = 1
-// TODO: MSW 핸들러 설정할 때 옮기기
-const MESSAGES = {
-  room_id: 2,
-  messages: [
-    {
-      id: 1,
-      sender_user_id: userId,
-      sender: {
-        id: userId,
-        nickname: '길동',
-        profile_image_url: 'https://...',
-      },
-      content:
-        'Lorem ipsum, dolor sit amet consectetur adipisicing elit. Aliquam rerum dolorum, perspiciatis culpa atque dolore libero itaque voluptates id odio nisi velit officiis, tempore reiciendis, hic commodi explicabo dolores nihil!',
-      status: 'SENT',
-      created_at: '2026-01-24T11:23:11Z',
-    },
-    {
-      id: 2,
-      sender_user_id: 2,
-      sender: {
-        id: 2,
-        nickname: '철수',
-        profile_image_url: 'https://...',
-      },
-      content: '안녕!',
-      status: 'SENT',
-      created_at: '2026-01-24T11:24:11Z',
-    },
-    {
-      id: 3,
-      sender_user_id: 3,
-      sender: {
-        id: 3,
-        nickname: '영희',
-        profile_image_url: 'https://...',
-      },
-      content:
-        'Lorem ipsum dolor sit amet consectetur adipisicing elit. Repudiandae modi architecto delectus velit doloribus libero fugit nam ducimus vel provident, commodi, assumenda animi hic ea officia deleniti ab nostrum fuga.',
-      status: 'SENT',
-      created_at: '2026-01-24T11:24:11Z',
-    },
-    {
-      id: 4,
-      sender_user_id: userId,
-      sender: {
-        id: userId,
-        nickname: '길동',
-        profile_image_url: 'https://...',
-      },
-      content: '뭐해??',
-      status: 'SENT',
-      created_at: '2026-01-24T11:25:11Z',
-    },
-    {
-      id: 5,
-      sender_user_id: 3,
-      sender: {
-        id: 3,
-        nickname: '영희',
-        profile_image_url: 'https://...',
-      },
-      content: '밤샘하는 중 ㅠㅠ',
-      status: 'SENT',
-      created_at: '2026-01-24T11:26:11Z',
-    },
-    {
-      id: 6,
-      sender_user_id: 2,
-      sender: {
-        id: 2,
-        nickname: '철수',
-        profile_image_url: 'https://...',
-      },
-      content: '메롱',
-      status: 'DELETED_BY_ADMIN',
-      created_at: '2026-01-24T11:27:11Z',
-    },
-    {
-      id: 7,
-      sender_user_id: userId,
-      sender: {
-        id: userId,
-        nickname: '길동',
-        profile_image_url: 'https://...',
-      },
-      content: '메롱',
-      status: 'DELETED_BY_ADMIN',
-      created_at: '2026-01-24T11:27:11Z',
-    },
-    {
-      id: 8,
-      sender_user_id: userId,
-      sender: {
-        id: userId,
-        nickname: '길동',
-        profile_image_url: 'https://...',
-      },
-      content:
-        'ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ',
-      status: 'SENT',
-      created_at: '2026-01-24T11:27:11Z',
-    },
-  ],
-} as const
 
 function MessageList() {
+  const roomId = useChatStore((state) => state.enteredRoomId)
+  const { data, isLoading, error } = useChatMessageList(roomId)
+  const messages = useMemo(
+    () => data?.pages.flatMap((page) => page.messages),
+    [data?.pages]
+  )
+
+  if (isLoading) return <Loading className="mt-9" />
+  if (error)
+    return (
+      <Error
+        className="mt-9"
+        message={
+          error.response?.data.detail ??
+          '메세지를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.'
+        }
+      />
+    )
+  if (messages?.length === 0)
+    return (
+      <div className="text-brand-gray-500 mt-9 py-9 text-center">
+        아직 대화가 없습니다. 첫 메세지를 보내보세요!
+      </div>
+    )
   return (
     <div className="mt-9">
+      {/* TODO: 무한 스크롤 처리 추가 */}
       <ul className="flex flex-col gap-4">
-        {MESSAGES.messages.map((message) =>
+        {messages?.map((message) =>
           message.sender.id === userId ? (
             <SentMessage key={message.id} message={message} />
           ) : (

--- a/src/features/chat/ui/ReceivedMessage.tsx
+++ b/src/features/chat/ui/ReceivedMessage.tsx
@@ -1,22 +1,13 @@
 import { formatTimeString } from '@/features/chat/lib/formatter'
 import { cn } from '@/shared/lib/cn'
 import Image from 'next/image'
+import { Message } from '@/features/chat/model/schema'
 
-// TODO: API 연동할 때 스키마에서 뽑은 타입으로 변경하기
-interface Message {
-  id: number
-  sender_user_id: number
-  sender: {
-    id: number
-    nickname: string
-    profile_image_url: string
-  }
-  content: string
-  status: 'SENT' | 'DELETED_BY_ADMIN'
-  created_at: string
+interface ReceivedMessageProps {
+  message: Message
 }
 
-function ReceivedMessage({ message }: { message: Message }) {
+function ReceivedMessage({ message }: ReceivedMessageProps) {
   const isBlindMessage = message.status === 'DELETED_BY_ADMIN'
 
   return (
@@ -26,7 +17,7 @@ function ReceivedMessage({ message }: { message: Message }) {
           <Image
             // TODO: 외부 이미지 사용하기 전에 넥스트 설정에 등록하기
             src={
-              //   message.sender.profile_image_url ??
+              message.sender.profileImageUrl ??
               '/images/profiles/default-1.webp'
             }
             alt={`${message.sender.nickname}의 프로필 이미지`}
@@ -50,7 +41,7 @@ function ReceivedMessage({ message }: { message: Message }) {
           {isBlindMessage ? '블라인드 처리된 메시지입니다.' : message.content}
         </span>
         <span className="text-brand-gray-300 text-sm font-medium">
-          {formatTimeString(new Date(message.created_at))}
+          {formatTimeString(message.createdAt)}
         </span>
       </div>
     </li>

--- a/src/features/chat/ui/SentMessage.tsx
+++ b/src/features/chat/ui/SentMessage.tsx
@@ -1,27 +1,18 @@
 import { formatTimeString } from '@/features/chat/lib/formatter'
 import { cn } from '@/shared/lib/cn'
+import { Message } from '@/features/chat/model/schema'
 
-// TODO: API 연동할 때 스키마에서 뽑은 타입으로 변경하기
-interface Message {
-  id: number
-  sender_user_id: number
-  sender: {
-    id: number
-    nickname: string
-    profile_image_url: string
-  }
-  content: string
-  status: 'SENT' | 'DELETED_BY_ADMIN'
-  created_at: string
+interface SentMessageProps {
+  message: Message
 }
 
-function SentMessage({ message }: { message: Message }) {
+function SentMessage({ message }: SentMessageProps) {
   const isBlindMessage = message.status === 'DELETED_BY_ADMIN'
 
   return (
     <li className="flex max-w-4/5 items-end gap-1 self-end">
       <span className="text-brand-gray-300 text-sm font-medium">
-        {formatTimeString(new Date(message.created_at))}
+        {formatTimeString(message.createdAt)}
       </span>
       <span
         className={cn(

--- a/src/shared/api/mocks/data/chat-data.ts
+++ b/src/shared/api/mocks/data/chat-data.ts
@@ -33,3 +33,34 @@ export const CHAT_ROOMS = [
     created_at: '2026-01-09T11:21:30Z',
   },
 ]
+
+const MESSAGE_COUNT = 100
+const MESSAGE_CONTENTS = [
+  '안녕하세용',
+  '반갑습니당',
+  'Lorem ipsum, dolor sit amet consectetur adipisicing elit. Aliquam rerum dolorum, perspiciatis culpa atque dolore libero itaque voluptates id odio nisi velit officiis, tempore reiciendis, hic commodi explicabo dolores nihil!',
+  '오늘 점심은 뭘 먹을까요?',
+  '어제 눈이 왔는데 눈사람을 못 만들었어요...',
+  '눈사람은 동글동글... 동글동글하다 동글동글한...',
+  '펄이 먹고 싶어서 밀크티를 시켰는데 펄이 없었어요. 그래서 그냥 먹었어요..',
+  '오늘은 진짜 일찍 자야지!!!!!!',
+]
+
+export const MESSAGES = Array.from({ length: MESSAGE_COUNT }, (_, i) => {
+  const userId = Math.floor(Math.random() * 2) + 1
+
+  return {
+    id: i + i,
+    sender_user_id: userId,
+    sender: {
+      id: userId,
+      nickname: userId === 1 ? '나' : '다른유저',
+      profile_image_url: null,
+    },
+    content: MESSAGE_CONTENTS[i % MESSAGE_CONTENTS.length],
+    status: 'SENT',
+    created_at: new Date(
+      Date.now() - (MESSAGE_COUNT - i) * 60000
+    ).toISOString(),
+  }
+})

--- a/src/shared/api/mocks/handlers/chat-handlers.ts
+++ b/src/shared/api/mocks/handlers/chat-handlers.ts
@@ -16,6 +16,29 @@ const getChatRoomList = http.get(
   }
 )
 
-const chatHandlers = [getChatRoomList]
+// ---------- 채팅방 입장 ----------
+const enterChatRoom = http.post<{ roomId?: string }>(
+  `${process.env.NEXT_PUBLIC_API_BASE_URL}/chat/:roomId`,
+  ({ params }) => {
+    const { roomId } = params
+    const parsedRoomId = Number(roomId)
+
+    if ([1, 2, 3, 4].includes(parsedRoomId ?? '')) {
+      return HttpResponse.json({
+        message: '채팅방에 입장했습니다.',
+        room: {
+          id: parsedRoomId,
+          name: CHAT_ROOMS.find((room) => room.id === parsedRoomId)?.name,
+        },
+      })
+    }
+    return HttpResponse.json(
+      { detail: '채팅방을 찾을 수 없습니다.' },
+      { status: 404 }
+    )
+  }
+)
+
+const chatHandlers = [getChatRoomList, enterChatRoom]
 
 export { chatHandlers }

--- a/src/shared/api/mocks/handlers/chat-handlers.ts
+++ b/src/shared/api/mocks/handlers/chat-handlers.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw'
-import { CHAT_ROOMS } from '@/shared/api/mocks/data/chat-data'
+import { CHAT_ROOMS, MESSAGES } from '@/shared/api/mocks/data/chat-data'
 
 // ---------- 채팅방 목록 조회 ----------
 const getChatRoomList = http.get(
@@ -39,6 +39,44 @@ const enterChatRoom = http.post<{ roomId?: string }>(
   }
 )
 
-const chatHandlers = [getChatRoomList, enterChatRoom]
+// ---------- 채팅 메세지 조회 ----------
+const getChatMessageList = http.get(
+  `${process.env.NEXT_PUBLIC_API_BASE_URL}/chat/:roomId/messages`,
+  async ({ params, request }) => {
+    const { roomId } = params
+
+    const url = new URL(request.url)
+    const size = url.searchParams.get('size') ?? 50
+    const parsedSize = Number(size)
+    const cursor = url.searchParams.get('cursor') ?? 1
+    const parsedCursor = Number(cursor)
+
+    const startIndex = (parsedCursor - 1) * parsedSize
+    const endIndex = startIndex + parsedSize
+    const hasMore = endIndex < MESSAGES.length
+
+    return HttpResponse.json({
+      room_id: Number(roomId),
+      messages: MESSAGES.slice(startIndex, endIndex),
+      next_cursor: hasMore ? parsedCursor + 1 : null,
+      has_more: hasMore,
+    })
+    // await new Promise(() => setTimeout(() => {}, 30000)).then(() => {
+    //   return HttpResponse.json({ rooms: CHAT_ROOMS })
+    // })
+    // return HttpResponse.json(
+    //   { detail: '채팅 이용이 제한된 사용자입니다.' },
+    //   { status: 403 }
+    // )
+    // return HttpResponse.json({
+    //   room_id: Number(roomId),
+    //   messages: [],
+    //   next_cursor: null,
+    //   has_more: false,
+    // })
+  }
+)
+
+const chatHandlers = [getChatRoomList, enterChatRoom, getChatMessageList]
 
 export { chatHandlers }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #56

## 📝작업 내용

> 채팅방 입장, 채팅 메세지 조회 API 연동
- 채팅방 입장 API 연동
- 채팅 메세지 조회 API 연동
- 기타
  - 이미 접속한 채팅방이 있는 상태에서 다른 채팅방 접속을 시도할시 모달 노출
  - 무한스크롤 UI 구현
  - 실시간 메세지 수신
  - 위의 사항은 이번 이슈에 포함해서 구현하면 PR이 너무 커질 것 같아서 작업하지 않았습니다.
  추후 다른 이슈에서 작업할 예정입니다.

## 🖼️스크린샷

https://github.com/user-attachments/assets/4adebfc7-6dea-441c-af5d-1e112f37fd2f

## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
