### PR TITLE
[Feature] 채팅 메세지 무한 스크롤 기능 구현

### DIFF
--- a/src/features/chat/lib/useInfiniteScroll.ts
+++ b/src/features/chat/lib/useInfiniteScroll.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react'
+import { type Message } from '@/features/chat/model/schema'
+
+function useInfiniteScroll(
+  messages: Message[] | undefined,
+  isFetchingNextPage: boolean,
+  hasNextPage: boolean,
+  isEnabled: boolean,
+  fetchNextPage: () => void
+) {
+  const containerRef = useRef<HTMLUListElement>(null)
+
+  useEffect(() => {
+    if (!isEnabled) return
+    if (!containerRef.current) return
+
+    const lastMessage = containerRef.current.lastElementChild
+    if (!lastMessage) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return
+        if (isFetchingNextPage || !hasNextPage || !isEnabled) return
+        fetchNextPage()
+      },
+      { threshold: 0.1 }
+    )
+
+    observer.observe(lastMessage)
+    return () => observer.disconnect()
+  }, [fetchNextPage, hasNextPage, isEnabled, isFetchingNextPage, messages])
+
+  return { containerRef }
+}
+
+export default useInfiniteScroll

--- a/src/features/chat/ui/EmptyState.tsx
+++ b/src/features/chat/ui/EmptyState.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/shared/lib/cn'
+
+interface EmptyStateProps {
+  message: string
+  className?: string
+}
+
+function EmptyState({ message, className }: EmptyStateProps) {
+  return (
+    <div className={cn('text-brand-gray-500 text-center', className)}>
+      {message}
+    </div>
+  )
+}
+
+export default EmptyState

--- a/src/features/chat/ui/MessageInput.tsx
+++ b/src/features/chat/ui/MessageInput.tsx
@@ -4,9 +4,9 @@ import { Input } from '@/shared/ui/input'
 function MessageInput() {
   return (
     // TODO: 메세지 전송 API 연결할 때 이벤트 핸들러 추가
-    <form className="border-t-brand-gray-200 mt-16 flex flex-col gap-4 border-t">
+    <form className="border-t-brand-gray-200 flex flex-col gap-4 border-t">
       <Input
-        className="border-none px-8 py-4"
+        className="border-none px-3 py-4"
         placeholder="메세지를 입력해주세요."
       />
       <Button

--- a/src/features/chat/ui/MessageList.tsx
+++ b/src/features/chat/ui/MessageList.tsx
@@ -7,47 +7,91 @@ import { useChatStore } from '@/features/chat/model/store'
 import { useMemo } from 'react'
 import Loading from '@/features/chat/ui/Loading'
 import Error from '@/features/chat/ui/Error'
+import useInfiniteScroll from '@/features/chat/lib/useInfiniteScroll'
+import { Button } from '@/shared/ui/Button'
+import { ChevronDownIcon } from 'lucide-react'
+import EmptyState from '@/features/chat/ui/EmptyState'
+import { cn } from '@/shared/lib/cn'
 
 // TODO: 유저 정보 스토어에 저장된 것 불러오기
 const userId = 1
+const MESSAGE_STATUS_LAYOUT = 'h-full flex flex-1 items-center justify-center'
 
 function MessageList() {
   const roomId = useChatStore((state) => state.enteredRoomId)
-  const { data, isLoading, error } = useChatMessageList(roomId)
+  const {
+    data,
+    isLoading,
+    error,
+    isFetchingNextPage,
+    hasNextPage,
+    isEnabled,
+    fetchNextPage,
+  } = useChatMessageList(roomId)
   const messages = useMemo(
     () => data?.pages.flatMap((page) => page.messages),
     [data?.pages]
   )
+  const { containerRef } = useInfiniteScroll(
+    messages,
+    isFetchingNextPage,
+    hasNextPage,
+    isEnabled,
+    fetchNextPage
+  )
 
-  if (isLoading) return <Loading className="mt-9" />
-  if (error)
-    return (
-      <Error
-        className="mt-9"
-        message={
-          error.response?.data.detail ??
-          '메세지를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.'
-        }
-      />
-    )
-  if (messages?.length === 0)
-    return (
-      <div className="text-brand-gray-500 mt-9 py-9 text-center">
-        아직 대화가 없습니다. 첫 메세지를 보내보세요!
-      </div>
-    )
+  const handleScrollButtonClick = () => {
+    if (!containerRef.current) return
+    containerRef.current.scrollTo({
+      top: containerRef.current.scrollHeight,
+      behavior: 'smooth',
+    })
+  }
+
   return (
-    <div className="mt-9">
-      {/* TODO: 무한 스크롤 처리 추가 */}
-      <ul className="flex flex-col gap-4">
-        {messages?.map((message) =>
-          message.sender.id === userId ? (
-            <SentMessage key={message.id} message={message} />
-          ) : (
-            <ReceivedMessage key={message.id} message={message} />
-          )
-        )}
-      </ul>
+    <div className="relative h-[calc(100vh-22rem)]">
+      {isLoading && <Loading className={cn(MESSAGE_STATUS_LAYOUT)} />}
+      {error && (
+        <Error
+          className={cn(MESSAGE_STATUS_LAYOUT)}
+          message={
+            error.response?.data.detail ??
+            '메세지를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.'
+          }
+        />
+      )}
+      {messages?.length === 0 && (
+        <EmptyState
+          className={cn(MESSAGE_STATUS_LAYOUT)}
+          message="아직 대화가 없습니다. 첫 메세지를 보내보세요!"
+        />
+      )}
+      {messages && (
+        <ul
+          className="flex h-full flex-col gap-4 overflow-y-auto pt-9 pb-16"
+          ref={containerRef}
+        >
+          {messages.map((message) =>
+            message.sender.id === userId ? (
+              <SentMessage key={message.id} message={message} />
+            ) : (
+              <ReceivedMessage key={message.id} message={message} />
+            )
+          )}
+          {isFetchingNextPage && <Loading />}
+        </ul>
+      )}
+      {messages && (
+        <Button
+          type="button"
+          className="absolute right-7 bottom-3 z-10 flex size-6 items-center justify-center rounded-full p-5 opacity-80 md:right-8 md:bottom-4"
+          variant="secondary"
+          onClick={handleScrollButtonClick}
+          aria-label="채팅방 아래로 이동"
+        >
+          <ChevronDownIcon className="size-6" />
+        </Button>
+      )}
     </div>
   )
 }

--- a/src/shared/api/mocks/data/chat-data.ts
+++ b/src/shared/api/mocks/data/chat-data.ts
@@ -50,7 +50,7 @@ export const MESSAGES = Array.from({ length: MESSAGE_COUNT }, (_, i) => {
   const userId = Math.floor(Math.random() * 2) + 1
 
   return {
-    id: i + i,
+    id: i + 1,
     sender_user_id: userId,
     sender: {
       id: userId,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #63

## 📝작업 내용

> 채팅 메세지 무한 스크롤 기능 구현
- 채팅창 높이에 제한을 두었습니다. 이 과정에서 부득이하게 높이를 제한하는 클래스를 커스텀해서 사용했습니다.
  - 메세지는 무한 스크롤이 가능해야 합니다.
  - 사용자가 채팅방에서 명시적으로 나가지 않으면 접속 이후의 모든 메세지를 조회할 수 있습니다.
  - 위의 사항을 종합해 봤을 때, 채팅창 높이에 제한을 두지 않으면 페이지 길이가 과도하게 길어질 수 있다고 판단하여 높이 제한을 두었습니다.
- 채팅창에 아래로 내려가기 버튼을 추가했습니다. 채팅창 우측 하단에 고정적으로 노출됩니다.

## 🖼️스크린샷

https://github.com/user-attachments/assets/cfac1a96-5b74-4af9-a92d-6021b521e8f8

## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
