### PR TITLE
[Fix] 채팅방 상단에 메세지 무한 스크롤 적용

### DIFF
--- a/src/features/chat-message-scroll/lib/useInfiniteScroll.ts
+++ b/src/features/chat-message-scroll/lib/useInfiniteScroll.ts
@@ -1,4 +1,5 @@
 import { type Message } from '@/entities/message/model/schema'
+import { InfiniteQueryObserverResult } from '@tanstack/react-query'
 import { useEffect, useRef } from 'react'
 
 function useInfiniteScroll(
@@ -6,22 +7,33 @@ function useInfiniteScroll(
   isFetchingNextPage: boolean,
   hasNextPage: boolean,
   isEnabled: boolean,
-  fetchNextPage: () => void
+  fetchNextPage: () => Promise<InfiniteQueryObserverResult>
 ) {
   const containerRef = useRef<HTMLUListElement>(null)
+  const prevScrollHeightRef = useRef<number>(0)
 
   useEffect(() => {
     if (!isEnabled) return
-    if (!containerRef.current) return
 
-    const lastMessage = containerRef.current.lastElementChild
+    const container = containerRef.current
+    if (!container) return
+
+    const lastMessage = container.lastElementChild
     if (!lastMessage) return
 
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (!entry.isIntersecting) return
         if (isFetchingNextPage || !hasNextPage || !isEnabled) return
-        fetchNextPage()
+
+        prevScrollHeightRef.current = container.scrollHeight
+        fetchNextPage().then(() => {
+          const prevScrollHeight = prevScrollHeightRef.current as number
+          const curScrollHeight = container.scrollHeight
+          const difference = Math.max(curScrollHeight - prevScrollHeight, 0)
+
+          container.scrollTop += difference
+        })
       },
       { threshold: 0.1 }
     )

--- a/src/shared/api/mocks/data/chat-data.ts
+++ b/src/shared/api/mocks/data/chat-data.ts
@@ -59,8 +59,6 @@ export const MESSAGES = Array.from({ length: MESSAGE_COUNT }, (_, i) => {
     },
     content: MESSAGE_CONTENTS[i % MESSAGE_CONTENTS.length],
     status: 'SENT',
-    created_at: new Date(
-      Date.now() - (MESSAGE_COUNT - i) * 60000
-    ).toISOString(),
+    created_at: new Date(Date.now() - i * 60000).toISOString(),
   }
 })

--- a/src/widgets/chat-message-list/ui/MessageList.tsx
+++ b/src/widgets/chat-message-list/ui/MessageList.tsx
@@ -68,7 +68,7 @@ function MessageList() {
       )}
       {messages && (
         <ul
-          className="flex h-full flex-col gap-4 overflow-y-auto pt-9 pb-16"
+          className="flex h-full flex-col-reverse gap-4 overflow-y-auto pt-9 pb-16"
           ref={containerRef}
         >
           {messages.map((message) =>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #72

## 📝작업 내용

> 채팅방 상단에 메세지 무한 스크롤 적용
- 채팅방 상단 영역에서 무한 스크롤이 가능하도록 수정
  - 과거 메세지를 무한 스크롤을 통해서 조회할 수 있습니다.
  - 새로운 데이터가 추가되었을 때 스크롤 위치가 고정되도록 수정했습니다.

## 🖼️스크린샷

https://github.com/user-attachments/assets/6d603858-b881-49c2-8dca-108673615c1e

## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
