### PR TITLE
refactor: 새로고침 시 유저 세션 유지 처리 (#89)

### DIFF
--- a/src/entities/session/lib/clear-session.ts
+++ b/src/entities/session/lib/clear-session.ts
@@ -4,7 +4,7 @@ import { useSessionStore } from '@/entities/session/store/session-store'
 export const clearAuthClientState = () => {
   if (typeof window !== 'undefined') {
     localStorage.removeItem('studigo_access_token')
-    sessionStorage.clear()
+    sessionStorage.removeItem('studigo_session_user')
   }
 
   useTokenStore.getState().clearAccessToken()

--- a/src/entities/session/store/session-store.ts
+++ b/src/entities/session/store/session-store.ts
@@ -1,14 +1,63 @@
 import { create } from 'zustand'
 import type { SessionUser } from '@/entities/session/model/types'
 
+const SESSION_USER_STORAGE_KEY = 'studigo_session_user'
+
+function getInitialUser(): SessionUser | null {
+  if (typeof window === 'undefined') return null
+
+  const raw = sessionStorage.getItem(SESSION_USER_STORAGE_KEY)
+  if (!raw) return null
+
+  try {
+    return JSON.parse(raw) as SessionUser
+  } catch {
+    sessionStorage.removeItem(SESSION_USER_STORAGE_KEY)
+    return null
+  }
+}
+
 interface SessionStore {
   user: SessionUser | null
   setUser: (user: SessionUser | null) => void
   clearUser: () => void
+  initializeUser: () => void
 }
 
 export const useSessionStore = create<SessionStore>((set) => ({
-  user: null,
-  setUser: (user) => set({ user }),
-  clearUser: () => set({ user: null }),
+  user: getInitialUser(),
+
+  setUser: (user) => {
+    set({ user })
+
+    if (typeof window === 'undefined') return
+
+    if (user) {
+      sessionStorage.setItem(SESSION_USER_STORAGE_KEY, JSON.stringify(user))
+    } else {
+      sessionStorage.removeItem(SESSION_USER_STORAGE_KEY)
+    }
+  },
+
+  clearUser: () => {
+    set({ user: null })
+    if (typeof window !== 'undefined') {
+      sessionStorage.removeItem(SESSION_USER_STORAGE_KEY)
+    }
+  },
+
+  initializeUser: () => {
+    if (typeof window === 'undefined') return
+    const raw = sessionStorage.getItem(SESSION_USER_STORAGE_KEY)
+    if (!raw) {
+      set({ user: null })
+      return
+    }
+    try {
+      set({ user: JSON.parse(raw) as SessionUser })
+    } catch {
+      sessionStorage.removeItem(SESSION_USER_STORAGE_KEY)
+      set({ user: null })
+    }
+  },
 }))


### PR DESCRIPTION
## #️⃣연관된 이슈

> #89 

## 📝작업 내용

> 로그인 시 유저 정보를 sessionStorage에 저장하고, 새로고침 후에도 복원되도록 수정해 유저 정보가 유지되도록 했습니다.

## 💬리뷰 요구사항 (선택)

> 로그인 후 유저 정보가 유지 잘 되는지 확인 부탁드립니다.

## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
