### PR TITLE
[Feature] 회원가입 api연결 #86

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
         "next-themes": "^0.4.6",
+        "nuqs": "^2.8.7",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.0",
@@ -4909,6 +4910,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -11249,6 +11256,43 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/nuqs": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/nuqs/-/nuqs-2.8.7.tgz",
+      "integrity": "sha512-wxzRUKn9ENnhX2jU5fBjpekaZZOSxmTzUqS4U2yMrpOaPU6ee7VUqSyHx81c/3FRyDFnFETTLjdsA+ZNKq2jhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/franky47"
+      },
+      "peerDependencies": {
+        "@remix-run/react": ">=2",
+        "@tanstack/react-router": "^1",
+        "next": ">=14.2.0",
+        "react": ">=18.2.0 || ^19.0.0-0",
+        "react-router": "^5 || ^6 || ^7",
+        "react-router-dom": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@tanstack/react-router": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react-router": {
+          "optional": true
+        },
+        "react-router-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
     "next-themes": "^0.4.6",
+    "nuqs": "^2.8.7",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.0",

--- a/src/app/auth/join/page.tsx
+++ b/src/app/auth/join/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { JoinFunnel } from '@/features/auth-join/ui'
 
 export default function Page() {
@@ -12,7 +13,11 @@ export default function Page() {
         </header>
 
         <div className="mt-8">
-          <JoinFunnel />
+          <Suspense
+            fallback={<div className="py-10 text-center">로딩중...</div>}
+          >
+            <JoinFunnel />
+          </Suspense>
         </div>
       </section>
     </main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Footer from '@/shared/ui/Footer'
 import { Toaster } from '@/shared/ui/Toaster'
 import Providers from '@/app/providers'
 import { HeaderWrapper } from '@/widgets/auth-header/ui/HeaderWrapper'
+import { NuqsAdapter } from 'nuqs/adapters/next/app'
 
 export const metadata: Metadata = {
   title: 'StudiGo',
@@ -25,14 +26,16 @@ const RootLayout = ({
   return (
     <html lang="ko" className={`${pretendard.variable} antialiased`}>
       <body className="font-pretendard flex min-h-screen flex-col">
-        <Providers>
-          <HeaderWrapper />
-          <main className="mx-auto w-full max-w-7xl flex-1 space-y-6 px-4 py-10">
-            {children}
-          </main>
-          <Footer />
-          <Toaster position="top-right" duration={1500} />
-        </Providers>
+        <NuqsAdapter>
+          <Providers>
+            <HeaderWrapper />
+            <main className="mx-auto w-full max-w-7xl flex-1 space-y-6 px-4 py-10">
+              {children}
+            </main>
+            <Footer />
+            <Toaster position="top-right" duration={1500} />
+          </Providers>
+        </NuqsAdapter>
       </body>
     </html>
   )

--- a/src/features/auth-join/api/email-auth-api.ts
+++ b/src/features/auth-join/api/email-auth-api.ts
@@ -1,0 +1,46 @@
+import { api } from '@/shared/api/client'
+
+export interface CheckEmailResponse {
+  message: string
+  check_token: string
+  expires_in: number
+}
+
+export interface SendEmailCodeResponse {
+  request_id: string
+  expires_in: number
+  cooldown: number
+}
+
+export interface VerifyEmailCodeResponse {
+  email_verify_token: string
+  expires_in: number
+}
+
+export async function checkEmail(email: string) {
+  const res = await api.post<CheckEmailResponse>('/auth/check-email', { email })
+  return res.data
+}
+
+export async function sendEmailCode(params: {
+  email: string
+  check_token: string
+}) {
+  const res = await api.post<SendEmailCodeResponse>(
+    '/auth/email-verification/signup/send-code',
+    params
+  )
+  return res.data
+}
+
+export async function verifyEmailCode(params: {
+  email: string
+  request_id: string
+  verification_code: string
+}) {
+  const res = await api.post<VerifyEmailCodeResponse>(
+    '/auth/email-verification/signup/confirm-code',
+    params
+  )
+  return res.data
+}

--- a/src/features/auth-join/api/nickname-api.ts
+++ b/src/features/auth-join/api/nickname-api.ts
@@ -1,14 +1,46 @@
-import { api } from '@/shared/api/client'
+export interface NicknameCheckRequest {
+  nickname: string
+}
 
-export interface CheckNicknameResponse {
+export interface NicknameCheckResponse {
   message: string
   check_token: string
   expires_in: number
 }
 
-export async function checkNickname(nickname: string) {
-  const res = await api.post<CheckNicknameResponse>('/auth/check-nickname', {
-    nickname,
+type ApiErrorBody = {
+  detail?: string
+  error_detail?: string
+}
+
+function buildUrl(pathWithApiV1: string) {
+  const base = (process.env.NEXT_PUBLIC_API_BASE_URL ?? '').replace(/\/+$/, '')
+  const normalizedPath = base.endsWith('/api/v1')
+    ? pathWithApiV1.replace(/^\/api\/v1/, '')
+    : pathWithApiV1
+  return `${base}${normalizedPath}`
+}
+
+export async function checkNickname(
+  nickname: string
+): Promise<NicknameCheckResponse> {
+  const url = buildUrl('/api/v1/auth/check-nickname')
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ nickname } satisfies NicknameCheckRequest),
   })
-  return res.data
+
+  if (!res.ok) {
+    let msg = '닉네임 중복 확인 실패'
+    try {
+      const data = (await res.json()) as ApiErrorBody
+      msg = data.detail ?? data.error_detail ?? msg
+    } catch {}
+    throw new Error(msg)
+  }
+
+  return (await res.json()) as NicknameCheckResponse
 }

--- a/src/features/auth-join/api/nickname-api.ts
+++ b/src/features/auth-join/api/nickname-api.ts
@@ -1,0 +1,14 @@
+import { api } from '@/shared/api/client'
+
+export interface CheckNicknameResponse {
+  message: string
+  check_token: string
+  expires_in: number
+}
+
+export async function checkNickname(nickname: string) {
+  const res = await api.post<CheckNicknameResponse>('/auth/check-nickname', {
+    nickname,
+  })
+  return res.data
+}

--- a/src/features/auth-join/api/query-keys.ts
+++ b/src/features/auth-join/api/query-keys.ts
@@ -1,0 +1,10 @@
+export const AUTH_JOIN_QUERY_KEYS = {
+  emailCheck: (email: string) => ['auth-join', 'email-check', email] as const,
+  emailSendCode: (email: string) =>
+    ['auth-join', 'email-send-code', email] as const,
+  emailVerifyCode: (email: string) =>
+    ['auth-join', 'email-verify-code', email] as const,
+  nicknameCheck: (nickname: string) =>
+    ['auth-join', 'nickname-check', nickname] as const,
+  signupEmail: () => ['auth-join', 'signup-email'] as const,
+}

--- a/src/features/auth-join/api/signup-api.ts
+++ b/src/features/auth-join/api/signup-api.ts
@@ -1,0 +1,69 @@
+import type { AxiosInstance } from 'axios'
+import {
+  CheckEmailRequest,
+  CheckEmailRequestSchema,
+  CheckEmailResponse,
+  CheckEmailResponseSchema,
+} from '@/features/auth-join/model/check-email-schema'
+import {
+  SendEmailCodeRequest,
+  SendEmailCodeRequestSchema,
+  SendEmailCodeResponse,
+  SendEmailCodeResponseSchema,
+} from '@/features/auth-join/model/send-email-code-schema'
+import {
+  VerifyEmailCodeRequest,
+  VerifyEmailCodeRequestSchema,
+  VerifyEmailCodeResponse,
+  VerifyEmailCodeResponseSchema,
+} from '@/features/auth-join/model/verify-email-code-schema'
+import {
+  NicknameCheckRequest,
+  NicknameCheckRequestSchema,
+  NicknameCheckResponse,
+  NicknameCheckResponseSchema,
+} from '@/features/auth-join/model/nickname-schema'
+import {
+  SignupRequest,
+  SignupRequestSchema,
+  SignupResponse,
+  SignupResponseSchema,
+} from '@/features/auth-join/model/signup-schema'
+
+export const createSignupApi = (apiClient: AxiosInstance) => ({
+  async checkEmail(payload: CheckEmailRequest): Promise<CheckEmailResponse> {
+    const body = CheckEmailRequestSchema.parse(payload)
+    const res = await apiClient.post('api/v1/auth/check-email', body)
+    return CheckEmailResponseSchema.parse(res.data)
+  },
+
+  async sendEmailCode(
+    payload: SendEmailCodeRequest
+  ): Promise<SendEmailCodeResponse> {
+    const body = SendEmailCodeRequestSchema.parse(payload)
+    const res = await apiClient.post('api/v1/auth/email/send-code', body)
+    return SendEmailCodeResponseSchema.parse(res.data)
+  },
+
+  async verifyEmailCode(
+    payload: VerifyEmailCodeRequest
+  ): Promise<VerifyEmailCodeResponse> {
+    const body = VerifyEmailCodeRequestSchema.parse(payload)
+    const res = await apiClient.post('api/v1/auth/email/verify-code', body)
+    return VerifyEmailCodeResponseSchema.parse(res.data)
+  },
+
+  async checkNickname(
+    payload: NicknameCheckRequest
+  ): Promise<NicknameCheckResponse> {
+    const body = NicknameCheckRequestSchema.parse(payload)
+    const res = await apiClient.post('api/v1/auth/check-nickname', body)
+    return NicknameCheckResponseSchema.parse(res.data)
+  },
+
+  async signup(payload: SignupRequest): Promise<SignupResponse> {
+    const body = SignupRequestSchema.parse(payload)
+    const res = await apiClient.post('api/v1/auth/signup', body)
+    return SignupResponseSchema.parse(res.data)
+  },
+})

--- a/src/features/auth-join/api/signup-api.ts
+++ b/src/features/auth-join/api/signup-api.ts
@@ -7,13 +7,15 @@ import {
 } from '@/features/auth-join/model/signup-schema'
 
 export type SignupGender = 'M' | 'F'
-
 export type SignupEmailRequest = SignupRequest
 
 export const signupEmail = async (
   payload: SignupRequest
-): Promise<SignupResponse> => {
+): Promise<SignupResponse | unknown> => {
   const body = SignupRequestSchema.parse(payload)
-  const res = await api.post('/auth/signup/email', body) // ✅ 필요시 '/auth/signup/email' 로 변경
-  return SignupResponseSchema.parse(res.data)
+
+  const res = await api.post('/auth/signup/email', body)
+
+  const parsed = SignupResponseSchema.safeParse(res.data)
+  return parsed.success ? parsed.data : res.data
 }

--- a/src/features/auth-join/api/signup-api.ts
+++ b/src/features/auth-join/api/signup-api.ts
@@ -8,10 +8,12 @@ import {
 
 export type SignupGender = 'M' | 'F'
 
-export async function signupEmail(
+export type SignupEmailRequest = SignupRequest
+
+export const signupEmail = async (
   payload: SignupRequest
-): Promise<SignupResponse> {
+): Promise<SignupResponse> => {
   const body = SignupRequestSchema.parse(payload)
-  const res = await api.post('/auth/signup', body) // ✅ 필요시 '/auth/signup/email' 로 변경
+  const res = await api.post('/auth/signup/email', body) // ✅ 필요시 '/auth/signup/email' 로 변경
   return SignupResponseSchema.parse(res.data)
 }

--- a/src/features/auth-join/api/signup-api.ts
+++ b/src/features/auth-join/api/signup-api.ts
@@ -1,69 +1,17 @@
-import type { AxiosInstance } from 'axios'
+import { api } from '@/shared/api/client'
 import {
-  CheckEmailRequest,
-  CheckEmailRequestSchema,
-  CheckEmailResponse,
-  CheckEmailResponseSchema,
-} from '@/features/auth-join/model/check-email-schema'
-import {
-  SendEmailCodeRequest,
-  SendEmailCodeRequestSchema,
-  SendEmailCodeResponse,
-  SendEmailCodeResponseSchema,
-} from '@/features/auth-join/model/send-email-code-schema'
-import {
-  VerifyEmailCodeRequest,
-  VerifyEmailCodeRequestSchema,
-  VerifyEmailCodeResponse,
-  VerifyEmailCodeResponseSchema,
-} from '@/features/auth-join/model/verify-email-code-schema'
-import {
-  NicknameCheckRequest,
-  NicknameCheckRequestSchema,
-  NicknameCheckResponse,
-  NicknameCheckResponseSchema,
-} from '@/features/auth-join/model/nickname-schema'
-import {
-  SignupRequest,
   SignupRequestSchema,
-  SignupResponse,
+  type SignupRequest,
   SignupResponseSchema,
+  type SignupResponse,
 } from '@/features/auth-join/model/signup-schema'
 
-export const createSignupApi = (apiClient: AxiosInstance) => ({
-  async checkEmail(payload: CheckEmailRequest): Promise<CheckEmailResponse> {
-    const body = CheckEmailRequestSchema.parse(payload)
-    const res = await apiClient.post('api/v1/auth/check-email', body)
-    return CheckEmailResponseSchema.parse(res.data)
-  },
+export type SignupGender = 'M' | 'F'
 
-  async sendEmailCode(
-    payload: SendEmailCodeRequest
-  ): Promise<SendEmailCodeResponse> {
-    const body = SendEmailCodeRequestSchema.parse(payload)
-    const res = await apiClient.post('api/v1/auth/email/send-code', body)
-    return SendEmailCodeResponseSchema.parse(res.data)
-  },
-
-  async verifyEmailCode(
-    payload: VerifyEmailCodeRequest
-  ): Promise<VerifyEmailCodeResponse> {
-    const body = VerifyEmailCodeRequestSchema.parse(payload)
-    const res = await apiClient.post('api/v1/auth/email/verify-code', body)
-    return VerifyEmailCodeResponseSchema.parse(res.data)
-  },
-
-  async checkNickname(
-    payload: NicknameCheckRequest
-  ): Promise<NicknameCheckResponse> {
-    const body = NicknameCheckRequestSchema.parse(payload)
-    const res = await apiClient.post('api/v1/auth/check-nickname', body)
-    return NicknameCheckResponseSchema.parse(res.data)
-  },
-
-  async signup(payload: SignupRequest): Promise<SignupResponse> {
-    const body = SignupRequestSchema.parse(payload)
-    const res = await apiClient.post('api/v1/auth/signup', body)
-    return SignupResponseSchema.parse(res.data)
-  },
-})
+export async function signupEmail(
+  payload: SignupRequest
+): Promise<SignupResponse> {
+  const body = SignupRequestSchema.parse(payload)
+  const res = await api.post('/auth/signup', body) // ✅ 필요시 '/auth/signup/email' 로 변경
+  return SignupResponseSchema.parse(res.data)
+}

--- a/src/features/auth-join/api/use-email-auth-mutations.ts
+++ b/src/features/auth-join/api/use-email-auth-mutations.ts
@@ -1,0 +1,41 @@
+'use client'
+
+import { useMutation } from '@tanstack/react-query'
+import {
+  checkEmail,
+  sendEmailCode,
+  verifyEmailCode,
+} from '@/features/auth-join/api/email-auth-api'
+import { AUTH_JOIN_QUERY_KEYS } from '@/features/auth-join/api/query-keys'
+
+export interface SendEmailCodePayload {
+  email: string
+  check_token: string
+}
+
+export interface VerifyEmailCodePayload {
+  email: string
+  request_id: string
+  verification_code: string
+}
+
+export const useCheckEmailMutation = (email: string) => {
+  return useMutation({
+    mutationKey: AUTH_JOIN_QUERY_KEYS.emailCheck(email),
+    mutationFn: () => checkEmail(email),
+  })
+}
+
+export const useSendEmailCodeMutation = () => {
+  return useMutation({
+    mutationKey: AUTH_JOIN_QUERY_KEYS.emailSendCode(''),
+    mutationFn: (payload: SendEmailCodePayload) => sendEmailCode(payload),
+  })
+}
+
+export const useVerifyEmailCodeMutation = () => {
+  return useMutation({
+    mutationKey: AUTH_JOIN_QUERY_KEYS.emailVerifyCode(''),
+    mutationFn: (payload: VerifyEmailCodePayload) => verifyEmailCode(payload),
+  })
+}

--- a/src/features/auth-join/api/use-nickname-check-mutation.ts
+++ b/src/features/auth-join/api/use-nickname-check-mutation.ts
@@ -1,0 +1,13 @@
+'use client'
+
+import { useMutation } from '@tanstack/react-query'
+import { checkNickname } from '@/features/auth-join/api/nickname-api'
+import { AUTH_JOIN_QUERY_KEYS } from '@/features/auth-join/api/query-keys'
+import type { NicknameCheckResponse } from '@/features/auth-join/api/nickname-api'
+
+export const useNicknameCheckMutation = (nickname: string) => {
+  return useMutation<NicknameCheckResponse, unknown, void>({
+    mutationKey: AUTH_JOIN_QUERY_KEYS.nicknameCheck(nickname),
+    mutationFn: async () => checkNickname(nickname),
+  })
+}

--- a/src/features/auth-join/api/use-signup-email-mutation.ts
+++ b/src/features/auth-join/api/use-signup-email-mutation.ts
@@ -1,0 +1,15 @@
+'use client'
+
+import { useMutation } from '@tanstack/react-query'
+import {
+  signupEmail,
+  type SignupEmailRequest,
+} from '@/features/auth-join/api/signup-api'
+import { AUTH_JOIN_QUERY_KEYS } from '@/features/auth-join/api/query-keys'
+
+export const useSignupEmailMutation = () => {
+  return useMutation({
+    mutationKey: AUTH_JOIN_QUERY_KEYS.signupEmail(),
+    mutationFn: (payload: SignupEmailRequest) => signupEmail(payload),
+  })
+}

--- a/src/features/auth-join/model/check-email-schema.ts
+++ b/src/features/auth-join/model/check-email-schema.ts
@@ -1,0 +1,26 @@
+import z from 'zod'
+import { ErrorResponseSchema } from '@/shared/api/error-schema'
+
+export const EmailSchema = z
+  .string()
+  .regex(
+    /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+    '올바른 이메일 형식이 아닙니다.'
+  )
+
+export const CheckEmailRequestSchema = z.object({
+  email: EmailSchema,
+})
+export type CheckEmailRequest = z.infer<typeof CheckEmailRequestSchema>
+
+export const CheckEmailResponseSchema = z.object({
+  message: z.string(),
+  check_token: z.string(),
+  expires_in: z.number(),
+})
+export type CheckEmailResponse = z.infer<typeof CheckEmailResponseSchema>
+
+export const CheckEmailErrorSchema = ErrorResponseSchema.extend({
+  error_code: z.enum(['INVALID_EMAIL_FORMAT', 'EMAIL_ALREADY_EXIST']),
+})
+export type CheckEmailError = z.infer<typeof CheckEmailErrorSchema>

--- a/src/features/auth-join/model/nickname-schema.ts
+++ b/src/features/auth-join/model/nickname-schema.ts
@@ -1,8 +1,8 @@
-import z from 'zod'
 import { ErrorResponseSchema } from '@/shared/api/error-schema'
+import z from 'zod'
 
 export const NicknameCheckRequestSchema = z.object({
-  nickname: z.string().min(1, '닉네임을 입력해주세요.'),
+  nickname: z.string().min(1),
 })
 export type NicknameCheckRequest = z.infer<typeof NicknameCheckRequestSchema>
 

--- a/src/features/auth-join/model/nickname-schema.ts
+++ b/src/features/auth-join/model/nickname-schema.ts
@@ -1,14 +1,15 @@
-import { ErrorResponseSchema } from '@/shared/api/error-schema'
 import z from 'zod'
+import { ErrorResponseSchema } from '@/shared/api/error-schema'
 
 export const NicknameCheckRequestSchema = z.object({
-  nickname: z.string().min(1),
+  nickname: z.string().min(1, '닉네임을 입력해주세요.'),
 })
 export type NicknameCheckRequest = z.infer<typeof NicknameCheckRequestSchema>
 
 export const NicknameCheckResponseSchema = z.object({
-  available: z.boolean(),
   message: z.string(),
+  check_token: z.string(),
+  expires_in: z.number(),
 })
 export type NicknameCheckResponse = z.infer<typeof NicknameCheckResponseSchema>
 

--- a/src/features/auth-join/model/send-email-code-schema.ts
+++ b/src/features/auth-join/model/send-email-code-schema.ts
@@ -1,0 +1,22 @@
+import z from 'zod'
+import { ErrorResponseSchema } from '@/shared/api/error-schema'
+import { EmailSchema } from '@/features/auth-join/model/check-email-schema'
+
+export const SendEmailCodeRequestSchema = z.object({
+  email: EmailSchema,
+  check_token: z.string().min(1, '이메일 중복 확인을 먼저 진행해주세요.'),
+})
+export type SendEmailCodeRequest = z.infer<typeof SendEmailCodeRequestSchema>
+
+export const SendEmailCodeResponseSchema = z.object({
+  request_id: z.string(),
+  expires_in: z.number(),
+  cooldown: z.number(),
+})
+export type SendEmailCodeResponse = z.infer<typeof SendEmailCodeResponseSchema>
+
+export const SendEmailCodeErrorSchema = ErrorResponseSchema.extend({
+  error_code: z.enum(['EMAIL_SEND_FAILED', 'TOO_MANY_REQUEST']),
+  retry_after: z.number().optional(),
+})
+export type SendEmailCodeError = z.infer<typeof SendEmailCodeErrorSchema>

--- a/src/features/auth-join/model/signup-schema.ts
+++ b/src/features/auth-join/model/signup-schema.ts
@@ -1,0 +1,82 @@
+import z from 'zod'
+import { ErrorResponseSchema } from '@/shared/api/error-schema'
+import { EmailSchema } from './check-email-schema'
+
+const PasswordSchema = z
+  .string()
+  .min(8, '비밀번호는 8자 이상이어야 합니다.')
+  .regex(/[A-Za-z]/, '비밀번호에 영문이 포함되어야 합니다.')
+  .regex(/[0-9]/, '비밀번호에 숫자가 포함되어야 합니다.')
+
+export const SignupRequestSchema = z
+  .object({
+    email: EmailSchema,
+    email_verification_token: z.string().min(1, '이메일 인증을 완료해주세요.'),
+
+    password: PasswordSchema,
+    password_confirm: z.string(),
+
+    nickname: z.string().min(1, '닉네임을 입력해주세요.'),
+    name: z.string().min(1, '이름을 입력해주세요.'),
+
+    gender: z.enum(['M', 'F']).optional(),
+    phone: z.string().optional(),
+    phone_verification_token: z.string().optional(),
+    birthdate: z.string().optional(),
+
+    terms_agreed: z.boolean(),
+    privacy_agreed: z.boolean(),
+    marketing_agreed: z.boolean().optional(),
+  })
+  .superRefine((v, ctx) => {
+    if (v.password !== v.password_confirm) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['password_confirm'],
+        message: '비밀번호가 일치하지 않습니다.',
+      })
+    }
+    if (!v.terms_agreed) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['terms_agreed'],
+        message: '이용약관에 동의해주세요.',
+      })
+    }
+    if (!v.privacy_agreed) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['privacy_agreed'],
+        message: '개인정보처리방침에 동의해주세요.',
+      })
+    }
+  })
+
+export type SignupRequest = z.infer<typeof SignupRequestSchema>
+
+export const SignupResponseSchema = z.object({
+  message: z.string(),
+  user: z.object({
+    id: z.number(),
+    email: z.string(),
+    nickname: z.string(),
+    created_at: z.string(),
+  }),
+})
+export type SignupResponse = z.infer<typeof SignupResponseSchema>
+
+export const SignupErrorSchema = ErrorResponseSchema.extend({
+  error_code: z.enum([
+    'INVALID_VERIFICATION_TOKEN',
+    'TOKEN_EXPIRED',
+    'PASSWORD_MISMATCH',
+    'INVALID_PASSWORD_FORMAT',
+    'EMAIL_ALREADY_EXISTS',
+    'NICKNAME_ALREADY_EXISTS',
+    'PHONE_ALREADY_EXISTS',
+    'TERMS_NOT_AGREED',
+    'TOO_MANY_REQUEST',
+  ]),
+  retry_after: z.number().optional(),
+})
+export type SignupError = z.infer<typeof SignupErrorSchema>

--- a/src/features/auth-join/model/signup-schema.ts
+++ b/src/features/auth-join/model/signup-schema.ts
@@ -11,7 +11,6 @@ const PasswordSchema = z
 export const SignupRequestSchema = z
   .object({
     email: EmailSchema,
-    email_verification_token: z.string().min(1, '이메일 인증을 완료해주세요.'),
 
     password: PasswordSchema,
     password_confirm: z.string(),
@@ -21,12 +20,14 @@ export const SignupRequestSchema = z
 
     gender: z.enum(['M', 'F']).optional(),
     phone: z.string().optional(),
-    phone_verification_token: z.string().optional(),
-    birthdate: z.string().optional(),
+    birthday: z.string().optional(),
 
-    terms_agreed: z.boolean(),
-    privacy_agreed: z.boolean(),
-    marketing_agreed: z.boolean().optional(),
+    agree_terms: z.boolean(),
+    agree_privacy: z.boolean(),
+    agree_marketing: z.boolean(),
+
+    nickname_check_token: z.string().min(1, '닉네임 중복 확인을 완료해주세요.'),
+    email_verify_token: z.string().min(1, '이메일 인증을 완료해주세요.'),
   })
   .superRefine((v, ctx) => {
     if (v.password !== v.password_confirm) {
@@ -36,17 +37,17 @@ export const SignupRequestSchema = z
         message: '비밀번호가 일치하지 않습니다.',
       })
     }
-    if (!v.terms_agreed) {
+    if (!v.agree_terms) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ['terms_agreed'],
+        path: ['agree_terms'],
         message: '이용약관에 동의해주세요.',
       })
     }
-    if (!v.privacy_agreed) {
+    if (!v.agree_privacy) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ['privacy_agreed'],
+        path: ['agree_privacy'],
         message: '개인정보처리방침에 동의해주세요.',
       })
     }

--- a/src/features/auth-join/model/verify-email-code-schema.ts
+++ b/src/features/auth-join/model/verify-email-code-schema.ts
@@ -1,0 +1,30 @@
+import z from 'zod'
+import { ErrorResponseSchema } from '@/shared/api/error-schema'
+import { EmailSchema } from './check-email-schema'
+
+export const VerifyPurposeSchema = z.enum(['SIGNUP'])
+export type VerifyPurpose = z.infer<typeof VerifyPurposeSchema>
+
+export const VerifyEmailCodeRequestSchema = z.object({
+  email: EmailSchema,
+  code: z.string().min(1, '인증코드를 입력해주세요.'),
+  purpose: VerifyPurposeSchema,
+})
+export type VerifyEmailCodeRequest = z.infer<
+  typeof VerifyEmailCodeRequestSchema
+>
+
+export const VerifyEmailCodeResponseSchema = z.object({
+  verified: z.boolean(),
+  message: z.string(),
+  verification_token: z.string(),
+})
+export type VerifyEmailCodeResponse = z.infer<
+  typeof VerifyEmailCodeResponseSchema
+>
+
+export const VerifyEmailCodeErrorSchema = ErrorResponseSchema.extend({
+  error_code: z.enum(['INVALID_CODE', 'TOO_MANY_REQUEST']),
+  retry_after: z.number().optional(),
+})
+export type VerifyEmailCodeError = z.infer<typeof VerifyEmailCodeErrorSchema>

--- a/src/features/auth-join/ui/DoneStep.tsx
+++ b/src/features/auth-join/ui/DoneStep.tsx
@@ -3,9 +3,11 @@
 import { Button } from '@/shared/ui/Button'
 import type { JoinFormState } from '@/features/auth-join/ui/JoinFunnel'
 
-export function DoneStep(props: { value: JoinFormState }) {
-  const formValue = props.value
+export interface DoneStepProps {
+  value: JoinFormState
+}
 
+export const DoneStep = ({ value }: DoneStepProps) => {
   return (
     <div className="text-center">
       <div className="border-brand-green text-brand-green mx-auto mb-5 flex size-12 items-center justify-center rounded-full border-2">
@@ -24,9 +26,9 @@ export function DoneStep(props: { value: JoinFormState }) {
       </p>
 
       <div className="bg-brand-gray-100 mt-8 rounded-md p-4 text-sm">
-        <InfoRow label="이메일" value={formValue.email} />
-        <InfoRow label="닉네임" value={formValue.nickname} />
-        <InfoRow label="이름" value={formValue.name} />
+        <InfoRow label="이메일" value={value.email} />
+        <InfoRow label="닉네임" value={value.nickname} />
+        <InfoRow label="이름" value={value.name} />
       </div>
 
       <Button
@@ -43,11 +45,16 @@ export function DoneStep(props: { value: JoinFormState }) {
   )
 }
 
-function InfoRow(props: { label: string; value?: string }) {
+interface InfoRowProps {
+  label: string
+  value?: string
+}
+
+const InfoRow = ({ label, value }: InfoRowProps) => {
   return (
     <div className="flex items-center justify-between py-1">
-      <span className="text-brand-gray-400">{props.label}</span>
-      <span className="text-brand-black font-medium">{props.value || '-'}</span>
+      <span className="text-brand-gray-400">{label}</span>
+      <span className="text-brand-black font-medium">{value || '-'}</span>
     </div>
   )
 }

--- a/src/features/auth-join/ui/DoneStep.tsx
+++ b/src/features/auth-join/ui/DoneStep.tsx
@@ -47,7 +47,6 @@ function InfoRow(props: { label: string; value?: string }) {
   return (
     <div className="flex items-center justify-between py-1">
       <span className="text-brand-gray-400">{props.label}</span>
-
       <span className="text-brand-black font-medium">{props.value || '-'}</span>
     </div>
   )

--- a/src/features/auth-join/ui/EmailPasswordStep.tsx
+++ b/src/features/auth-join/ui/EmailPasswordStep.tsx
@@ -1,27 +1,26 @@
 'use client'
 
-import { useMutation } from '@tanstack/react-query'
-import { isAxiosError } from 'axios'
 import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
+import { isAxiosError } from 'axios'
 
 import { Button } from '@/shared/ui/Button'
 import { Input } from '@/shared/ui/input'
 import type { JoinFormState } from '@/features/auth-join/ui/JoinFunnel'
 import {
-  checkEmail,
-  sendEmailCode,
-  verifyEmailCode,
-} from '@/features/auth-join/api/email-auth-api'
+  useCheckEmailMutation,
+  useSendEmailCodeMutation,
+  useVerifyEmailCodeMutation,
+} from '@/features/auth-join/api/use-email-auth-mutations'
 
-type ApiErrorBody = {
+interface ApiErrorBody {
   detail?: string
   error_detail?: string
   error_code?: string
   retry_after?: number
 }
 
-function getErrorMessage(error: unknown, fallback: string) {
+const getErrorMessage = (error: unknown, fallback: string) => {
   if (!isAxiosError<ApiErrorBody>(error)) return fallback
   return (
     error.response?.data?.detail ??
@@ -32,20 +31,20 @@ function getErrorMessage(error: unknown, fallback: string) {
 
 const EMAIL_REGEX = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/
 
-interface EmailPasswordStepProps {
+export interface EmailPasswordStepProps {
   value: JoinFormState
   onChange: (patch: Partial<JoinFormState>) => void
 }
 
-export function EmailPasswordStep({ value, onChange }: EmailPasswordStepProps) {
-  const PASSWORD_RULE_TEXT =
-    '영문/숫자/특수문자 조합 8자 이상으로 입력해 주세요.'
-
+export const EmailPasswordStep = ({
+  value,
+  onChange,
+}: EmailPasswordStepProps) => {
+  const passwordRuleText = '영문/숫자/특수문자 조합 8자 이상으로 입력해 주세요.'
   const [emailCheckError, setEmailCheckError] = useState<string | null>(null)
 
   const isEmailFormatValid =
     value.email.length === 0 || EMAIL_REGEX.test(value.email)
-
   const isCodeSent = useMemo(
     () => Boolean(value.emailRequestId),
     [value.emailRequestId]
@@ -57,72 +56,23 @@ export function EmailPasswordStep({ value, onChange }: EmailPasswordStepProps) {
   const isPasswordMatch =
     isConfirmTouched && value.password === value.passwordConfirm
 
-  const checkEmailMut = useMutation({
-    mutationFn: () => checkEmail(value.email),
-    onSuccess: (data) => {
-      onChange({ emailCheckToken: data.check_token })
-      setEmailCheckError(null)
-      toast.success(data.message || '사용 가능한 이메일입니다.')
-    },
-    onError: (e: unknown) => {
-      onChange({ emailCheckToken: '' })
-
-      const msg = getErrorMessage(e, '이미 가입된 이메일입니다.')
-      setEmailCheckError(msg)
-      toast.error(msg)
-    },
-  })
-
-  const sendCodeMut = useMutation({
-    mutationFn: () =>
-      sendEmailCode({
-        email: value.email,
-        check_token: value.emailCheckToken,
-      }),
-    onSuccess: (data) => {
-      onChange({
-        emailRequestId: data.request_id,
-        emailCode: '',
-        emailVerified: false,
-        emailVerifyToken: '',
-      })
-      toast.success('인증코드를 발송했어요.')
-    },
-    onError: (e: unknown) =>
-      toast.error(getErrorMessage(e, '인증코드 발송 실패')),
-  })
-
-  const verifyCodeMut = useMutation({
-    mutationFn: () =>
-      verifyEmailCode({
-        email: value.email,
-        request_id: value.emailRequestId,
-        verification_code: value.emailCode,
-      }),
-    onSuccess: (data) => {
-      onChange({
-        emailVerified: true,
-        emailVerifyToken: data.email_verify_token,
-      })
-      toast.success('이메일 인증 완료')
-    },
-    onError: (e: unknown) =>
-      toast.error(getErrorMessage(e, '인증코드 확인 실패')),
-  })
+  const checkEmailMutation = useCheckEmailMutation(value.email)
+  const sendEmailCodeMutation = useSendEmailCodeMutation()
+  const verifyEmailCodeMutation = useVerifyEmailCodeMutation()
 
   const canCheckEmail =
-    Boolean(value.email) && isEmailFormatValid && !checkEmailMut.isPending
+    Boolean(value.email) && isEmailFormatValid && !checkEmailMutation.isPending
 
   const canSendCode =
     Boolean(value.email) &&
     Boolean(value.emailCheckToken) &&
-    !sendCodeMut.isPending
+    !sendEmailCodeMutation.isPending
 
   const canVerify =
     Boolean(value.email) &&
     Boolean(value.emailCode) &&
     Boolean(value.emailRequestId) &&
-    !verifyCodeMut.isPending
+    !verifyEmailCodeMutation.isPending
 
   const authButtonLabel = value.emailVerified
     ? '인증완료'
@@ -130,28 +80,58 @@ export function EmailPasswordStep({ value, onChange }: EmailPasswordStepProps) {
       ? '확인'
       : '인증코드 발송'
 
-  const onClickAuthButton = () => {
+  const onClickAuthButton = async () => {
     if (value.emailVerified) return
+
     if (!isCodeSent) {
-      sendCodeMut.mutate()
+      try {
+        const data = await sendEmailCodeMutation.mutateAsync({
+          email: value.email,
+          check_token: value.emailCheckToken,
+        })
+
+        onChange({
+          emailRequestId: data.request_id,
+          emailCode: '',
+          emailVerified: false,
+          emailVerifyToken: '',
+        })
+        toast.success('인증코드를 발송했어요.')
+      } catch (error: unknown) {
+        toast.error(getErrorMessage(error, '인증코드 발송 실패'))
+      }
       return
     }
-    verifyCodeMut.mutate()
+
+    try {
+      const data = await verifyEmailCodeMutation.mutateAsync({
+        email: value.email,
+        request_id: value.emailRequestId,
+        verification_code: value.emailCode,
+      })
+
+      onChange({
+        emailVerified: true,
+        emailVerifyToken: data.email_verify_token,
+      })
+      toast.success('이메일 인증 완료')
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, '인증코드 확인 실패'))
+    }
   }
 
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2">
         <label className="text-sm">이메일</label>
+
         <div className="flex gap-2">
           <Input
             value={value.email}
-            onChange={(e) => {
+            onChange={(event) => {
               setEmailCheckError(null)
-
               onChange({
-                email: e.target.value,
-
+                email: event.target.value,
                 emailCheckToken: '',
                 emailRequestId: '',
                 emailCode: '',
@@ -161,11 +141,27 @@ export function EmailPasswordStep({ value, onChange }: EmailPasswordStepProps) {
             }}
             placeholder="example@email.com"
           />
+
           <Button
             type="button"
             variant="outline"
             disabled={!canCheckEmail}
-            onClick={() => checkEmailMut.mutate()}
+            onClick={async () => {
+              try {
+                const data = await checkEmailMutation.mutateAsync()
+                onChange({ emailCheckToken: data.check_token })
+                setEmailCheckError(null)
+                toast.success(data.message || '사용 가능한 이메일입니다.')
+              } catch (error: unknown) {
+                onChange({ emailCheckToken: '' })
+                const message = getErrorMessage(
+                  error,
+                  '이미 가입된 이메일입니다.'
+                )
+                setEmailCheckError(message)
+                toast.error(message)
+              }
+            }}
           >
             중복확인
           </Button>
@@ -188,10 +184,11 @@ export function EmailPasswordStep({ value, onChange }: EmailPasswordStepProps) {
 
       <div className="flex flex-col gap-2">
         <label className="text-sm">이메일 인증</label>
+
         <div className="flex gap-2">
           <Input
             value={value.emailCode}
-            onChange={(e) => onChange({ emailCode: e.target.value })}
+            onChange={(event) => onChange({ emailCode: event.target.value })}
             placeholder="인증코드 입력"
             disabled={!isCodeSent || value.emailVerified}
           />
@@ -222,10 +219,9 @@ export function EmailPasswordStep({ value, onChange }: EmailPasswordStepProps) {
         <Input
           type="password"
           value={value.password}
-          onChange={(e) => onChange({ password: e.target.value })}
+          onChange={(event) => onChange({ password: event.target.value })}
         />
-
-        <p className="text-brand-gray-400 text-xs">{PASSWORD_RULE_TEXT}</p>
+        <p className="text-brand-gray-400 text-xs">{passwordRuleText}</p>
 
         {isPasswordMismatch && (
           <p className="text-brand-error text-xs">
@@ -239,7 +235,9 @@ export function EmailPasswordStep({ value, onChange }: EmailPasswordStepProps) {
         <Input
           type="password"
           value={value.passwordConfirm}
-          onChange={(e) => onChange({ passwordConfirm: e.target.value })}
+          onChange={(event) =>
+            onChange({ passwordConfirm: event.target.value })
+          }
           className={
             isPasswordMismatch
               ? 'border-brand-error focus-visible:ring-brand-error'

--- a/src/features/auth-join/ui/EmailPasswordStep.tsx
+++ b/src/features/auth-join/ui/EmailPasswordStep.tsx
@@ -1,129 +1,261 @@
 'use client'
 
-import type { ReactNode } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
 import { Button } from '@/shared/ui/Button'
 import { Input } from '@/shared/ui/input'
 import type { JoinFormState } from '@/features/auth-join/ui/JoinFunnel'
+import {
+  checkEmail,
+  sendEmailCode,
+  verifyEmailCode,
+} from '@/features/auth-join/api/email-auth-api'
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-const LETTER_REGEX = /[A-Za-z]/
-const NUMBER_REGEX = /[0-9]/
-const SPECIAL_REGEX = /[^A-Za-z0-9]/
-
-function isValidEmail(email: string) {
-  return EMAIL_REGEX.test(email)
+type ApiErrorBody = {
+  detail?: string
+  error_detail?: string
+  error_code?: string
+  retry_after?: number
 }
 
-function passwordChecks(password: string) {
-  return {
-    min8: password.length >= 8,
-    combo:
-      LETTER_REGEX.test(password) &&
-      NUMBER_REGEX.test(password) &&
-      SPECIAL_REGEX.test(password),
-  }
-}
-
-export function EmailPasswordStep(props: {
-  value: JoinFormState
-  onChange: (patch: Partial<JoinFormState>) => void
-}) {
-  const formValue = props.value
-
-  const emailTouched = formValue.email.length > 0
-  const emailOk = isValidEmail(formValue.email)
-
-  const password = formValue.password
-  const passwordTouched = password.length > 0
-  const passwordRule = passwordChecks(password)
-
-  const passwordRuleClass = (ok: boolean) => {
-    if (!passwordTouched) return 'text-brand-gray-300'
-    return ok ? '!text-brand-green' : '!text-brand-error'
-  }
-
-  const passwordConfirmTouched = formValue.passwordConfirm.length > 0
-  const passwordConfirmOk =
-    formValue.passwordConfirm.length > 0 &&
-    formValue.passwordConfirm === formValue.password
-
+function getErrorMessage(error: unknown, fallback: string) {
+  if (!isAxiosError<ApiErrorBody>(error)) return fallback
   return (
-    <div className="space-y-5">
-      <Field label="이메일">
-        <div className="flex gap-2">
-          <Input
-            type="email"
-            size="sm"
-            placeholder="이메일을 입력해주세요."
-            value={formValue.email}
-            onChange={(e) => props.onChange({ email: e.target.value })}
-            autoComplete="email"
-          />
-          <Button
-            type="button"
-            size="reg"
-            variant="secondary"
-            className="h-12 w-24"
-          >
-            인증
-          </Button>
-        </div>
-
-        {emailTouched && !emailOk && (
-          <p className="text-brand-error mt-1 text-sm">
-            이메일 형식에 맞춰 작성해주세요.
-          </p>
-        )}
-      </Field>
-
-      <Field label="비밀번호">
-        <Input
-          type="password"
-          size="sm"
-          placeholder="비밀번호를 입력해주세요."
-          value={formValue.password}
-          onChange={(e) => props.onChange({ password: e.target.value })}
-          autoComplete="new-password"
-        />
-
-        <ul className="mt-2 space-y-1 text-xs">
-          <li className={passwordRuleClass(passwordRule.min8)}>✓ 최소 8글자</li>
-          <li className={passwordRuleClass(passwordRule.combo)}>
-            ✓ 영문, 숫자, 특수문자 조합
-          </li>
-        </ul>
-      </Field>
-
-      <Field label="비밀번호 확인">
-        <Input
-          type="password"
-          size="sm"
-          placeholder="비밀번호를 한 번 더 입력해주세요."
-          value={formValue.passwordConfirm}
-          onChange={(e) => props.onChange({ passwordConfirm: e.target.value })}
-          autoComplete="new-password"
-        />
-
-        {passwordConfirmTouched && !passwordConfirmOk && (
-          <p className="text-brand-error mt-1 text-sm">
-            비밀번호가 일치하지 않습니다.
-          </p>
-        )}
-        {passwordConfirmOk && (
-          <p className="text-brand-green mt-1 text-sm">
-            비밀번호가 일치합니다.
-          </p>
-        )}
-      </Field>
-    </div>
+    error.response?.data?.detail ??
+    error.response?.data?.error_detail ??
+    fallback
   )
 }
 
-function Field(props: { label: string; children: ReactNode }) {
+const EMAIL_REGEX = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/
+
+interface EmailPasswordStepProps {
+  value: JoinFormState
+  onChange: (patch: Partial<JoinFormState>) => void
+}
+
+export function EmailPasswordStep({ value, onChange }: EmailPasswordStepProps) {
+  const PASSWORD_RULE_TEXT =
+    '영문/숫자/특수문자 조합 8자 이상으로 입력해 주세요.'
+
+  const [emailCheckError, setEmailCheckError] = useState<string | null>(null)
+
+  const isEmailFormatValid =
+    value.email.length === 0 || EMAIL_REGEX.test(value.email)
+
+  const isCodeSent = useMemo(
+    () => Boolean(value.emailRequestId),
+    [value.emailRequestId]
+  )
+
+  const isConfirmTouched = value.passwordConfirm.length > 0
+  const isPasswordMismatch =
+    isConfirmTouched && value.password !== value.passwordConfirm
+  const isPasswordMatch =
+    isConfirmTouched && value.password === value.passwordConfirm
+
+  const checkEmailMut = useMutation({
+    mutationFn: () => checkEmail(value.email),
+    onSuccess: (data) => {
+      onChange({ emailCheckToken: data.check_token })
+      setEmailCheckError(null)
+      toast.success(data.message || '사용 가능한 이메일입니다.')
+    },
+    onError: (e: unknown) => {
+      onChange({ emailCheckToken: '' })
+
+      const msg = getErrorMessage(e, '이미 가입된 이메일입니다.')
+      setEmailCheckError(msg)
+      toast.error(msg)
+    },
+  })
+
+  const sendCodeMut = useMutation({
+    mutationFn: () =>
+      sendEmailCode({
+        email: value.email,
+        check_token: value.emailCheckToken,
+      }),
+    onSuccess: (data) => {
+      onChange({
+        emailRequestId: data.request_id,
+        emailCode: '',
+        emailVerified: false,
+        emailVerifyToken: '',
+      })
+      toast.success('인증코드를 발송했어요.')
+    },
+    onError: (e: unknown) =>
+      toast.error(getErrorMessage(e, '인증코드 발송 실패')),
+  })
+
+  const verifyCodeMut = useMutation({
+    mutationFn: () =>
+      verifyEmailCode({
+        email: value.email,
+        request_id: value.emailRequestId,
+        verification_code: value.emailCode,
+      }),
+    onSuccess: (data) => {
+      onChange({
+        emailVerified: true,
+        emailVerifyToken: data.email_verify_token,
+      })
+      toast.success('이메일 인증 완료')
+    },
+    onError: (e: unknown) =>
+      toast.error(getErrorMessage(e, '인증코드 확인 실패')),
+  })
+
+  const canCheckEmail =
+    Boolean(value.email) && isEmailFormatValid && !checkEmailMut.isPending
+
+  const canSendCode =
+    Boolean(value.email) &&
+    Boolean(value.emailCheckToken) &&
+    !sendCodeMut.isPending
+
+  const canVerify =
+    Boolean(value.email) &&
+    Boolean(value.emailCode) &&
+    Boolean(value.emailRequestId) &&
+    !verifyCodeMut.isPending
+
+  const authButtonLabel = value.emailVerified
+    ? '인증완료'
+    : isCodeSent
+      ? '확인'
+      : '인증코드 발송'
+
+  const onClickAuthButton = () => {
+    if (value.emailVerified) return
+    if (!isCodeSent) {
+      sendCodeMut.mutate()
+      return
+    }
+    verifyCodeMut.mutate()
+  }
+
   return (
-    <div className="space-y-1">
-      <label className="text-brand-gray-500 text-sm">{props.label}</label>
-      {props.children}
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <label className="text-sm">이메일</label>
+        <div className="flex gap-2">
+          <Input
+            value={value.email}
+            onChange={(e) => {
+              setEmailCheckError(null)
+
+              onChange({
+                email: e.target.value,
+
+                emailCheckToken: '',
+                emailRequestId: '',
+                emailCode: '',
+                emailVerified: false,
+                emailVerifyToken: '',
+              })
+            }}
+            placeholder="example@email.com"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!canCheckEmail}
+            onClick={() => checkEmailMut.mutate()}
+          >
+            중복확인
+          </Button>
+        </div>
+
+        {value.email.length > 0 && !isEmailFormatValid && (
+          <p className="text-brand-error text-xs">
+            올바른 이메일 형식으로 입력해 주세요.
+          </p>
+        )}
+
+        {value.emailCheckToken && !emailCheckError && isEmailFormatValid && (
+          <p className="text-brand-green text-xs">사용 가능한 이메일입니다.</p>
+        )}
+
+        {emailCheckError && (
+          <p className="text-brand-error text-xs">{emailCheckError}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm">이메일 인증</label>
+        <div className="flex gap-2">
+          <Input
+            value={value.emailCode}
+            onChange={(e) => onChange({ emailCode: e.target.value })}
+            placeholder="인증코드 입력"
+            disabled={!isCodeSent || value.emailVerified}
+          />
+
+          <Button
+            type="button"
+            variant="outline"
+            disabled={
+              value.emailVerified
+                ? true
+                : isCodeSent
+                  ? !canVerify
+                  : !canSendCode
+            }
+            onClick={onClickAuthButton}
+          >
+            {authButtonLabel}
+          </Button>
+        </div>
+
+        {value.emailVerified && (
+          <p className="text-brand-green text-xs">인증 완료</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm">비밀번호</label>
+        <Input
+          type="password"
+          value={value.password}
+          onChange={(e) => onChange({ password: e.target.value })}
+        />
+
+        <p className="text-brand-gray-400 text-xs">{PASSWORD_RULE_TEXT}</p>
+
+        {isPasswordMismatch && (
+          <p className="text-brand-error text-xs">
+            비밀번호가 일치하지 않아요.
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="text-sm">비밀번호 확인</label>
+        <Input
+          type="password"
+          value={value.passwordConfirm}
+          onChange={(e) => onChange({ passwordConfirm: e.target.value })}
+          className={
+            isPasswordMismatch
+              ? 'border-brand-error focus-visible:ring-brand-error'
+              : undefined
+          }
+        />
+
+        {isPasswordMismatch && (
+          <p className="text-brand-error text-xs">
+            비밀번호가 일치하지 않아요.
+          </p>
+        )}
+        {isPasswordMatch && (
+          <p className="text-brand-green text-xs">비밀번호가 일치해요.</p>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/features/auth-join/ui/ExtraInfoStep.tsx
+++ b/src/features/auth-join/ui/ExtraInfoStep.tsx
@@ -1,147 +1,45 @@
 'use client'
 
-import type { ChangeEvent, ReactNode } from 'react'
-import { Button } from '@/shared/ui/Button'
+import type {
+  GenderUI,
+  JoinFormState,
+} from '@/features/auth-join/ui/JoinFunnel'
 import { Input } from '@/shared/ui/input'
 import { Dropdown } from '@/shared/ui/dropdown/Dropdown'
-import type { JoinFormState } from '@/features/auth-join/ui/JoinFunnel'
 
-const NICKNAME_REGEX = /^[가-힣a-zA-Z0-9]+$/
-
-const BANNED_WORDS = [
-  '씨발',
-  '개새끼',
-  '관리자',
-  '운영진',
-  '씨',
-  '개새',
-] as const
-
-function nicknameChecks(nickname: string) {
-  const lower = nickname.toLowerCase()
-
-  return {
-    length: nickname.length >= 2 && nickname.length <= 12,
-    charset: NICKNAME_REGEX.test(nickname),
-    banned: BANNED_WORDS.some((word) => lower.includes(word.toLowerCase())),
-  }
-}
-
-function formatBirth(input: string) {
-  const digits = input.replace(/\D/g, '').slice(0, 8)
-
-  const year = digits.slice(0, 4)
-  const month = digits.slice(4, 6)
-  const day = digits.slice(6, 8)
-
-  if (digits.length <= 4) return year
-  if (digits.length <= 6) return `${year}-${month}`
-  return `${year}-${month}-${day}`
-}
-
-export function ExtraInfoStep(props: {
+interface ExtraInfoStepProps {
   value: JoinFormState
   onChange: (patch: Partial<JoinFormState>) => void
-}) {
-  const formValue = props.value
-
-  const nickname = formValue.nickname
-  const nicknameTouched = nickname.length > 0
-  const nicknameRule = nicknameChecks(nickname)
-
-  const nicknameOk =
-    nicknameRule.length && nicknameRule.charset && !nicknameRule.banned
-
-  const ruleClass = (ok: boolean) => {
-    if (!nicknameTouched) return 'text-brand-gray-300'
-    return ok ? '!text-brand-green' : '!text-brand-error'
-  }
-
-  const onBirthChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const next = formatBirth(e.target.value)
-    props.onChange({ birth: next })
-  }
-
-  return (
-    <div className="space-y-5">
-      <Field label="닉네임">
-        <div className="flex gap-2">
-          <Input
-            size="sm"
-            placeholder="닉네임을 입력해주세요."
-            value={nickname}
-            onChange={(e) => props.onChange({ nickname: e.target.value })}
-          />
-          <Button
-            type="button"
-            size="reg"
-            variant="secondary"
-            className="h-12 w-28"
-            disabled={!nicknameOk}
-          >
-            중복 확인
-          </Button>
-        </div>
-
-        <ul className="mt-2 space-y-1 text-xs">
-          <li className={ruleClass(nicknameRule.length)}>
-            ✓ 최소 2글자, 최대 12글자
-          </li>
-          <li className={ruleClass(nicknameRule.charset)}>
-            ✓ 한글, 영문, 숫자만 사용 가능(공백 및 특수문자 불가)
-          </li>
-          <li className={ruleClass(!nicknameRule.banned)}>
-            ✓ 금지어 포함 불가
-          </li>
-        </ul>
-
-        {nicknameTouched && nicknameRule.banned && (
-          <p className="text-brand-error mt-1 text-sm">
-            사용할 수 없는 단어가 포함되어 있습니다.
-          </p>
-        )}
-
-        {nicknameTouched && nicknameOk && (
-          <p className="text-brand-green mt-1 text-sm">
-            사용 가능한 닉네임입니다.
-          </p>
-        )}
-      </Field>
-
-      <Field label="생년월일">
-        <Input
-          size="sm"
-          placeholder="YYYY-MM-DD"
-          value={formValue.birth}
-          onChange={onBirthChange}
-          inputMode="numeric"
-        />
-      </Field>
-
-      <Field label="성별">
-        <Dropdown
-          value={formValue.gender}
-          onValueChange={(value) => props.onChange({ gender: value })}
-        >
-          <Dropdown.Trigger size="lg">
-            <Dropdown.Value placeholder="성별을 선택해주세요." />
-          </Dropdown.Trigger>
-
-          <Dropdown.Content>
-            <Dropdown.Item value="MALE">남성</Dropdown.Item>
-            <Dropdown.Item value="FEMALE">여성</Dropdown.Item>
-          </Dropdown.Content>
-        </Dropdown>
-      </Field>
-    </div>
-  )
 }
 
-function Field(props: { label: string; children: ReactNode }) {
+export function ExtraInfoStep({ value, onChange }: ExtraInfoStepProps) {
   return (
-    <div className="space-y-1">
-      <label className="text-brand-gray-500 text-sm">{props.label}</label>
-      {props.children}
+    <div className="flex flex-col gap-4">
+      <div>
+        <label className="text-sm">닉네임</label>
+        <Input
+          value={value.nickname}
+          onChange={(e) => onChange({ nickname: e.target.value })}
+        />
+      </div>
+
+      <div>
+        <label className="text-sm">생년월일</label>
+        <Input
+          type="date"
+          value={value.birth}
+          onChange={(e) => onChange({ birth: e.target.value })}
+        />
+      </div>
+
+      <div>
+        <label className="text-sm">성별</label>
+
+        <Dropdown
+          value={value.gender || undefined}
+          onValueChange={(v: string) => onChange({ gender: v as GenderUI })}
+        />
+      </div>
     </div>
   )
 }

--- a/src/features/auth-join/ui/ExtraInfoStep.tsx
+++ b/src/features/auth-join/ui/ExtraInfoStep.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { useMutation } from '@tanstack/react-query'
-import { isAxiosError } from 'axios'
 import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
+import { isAxiosError } from 'axios'
 
 import type {
   GenderUI,
@@ -12,16 +11,14 @@ import type {
 import { Input } from '@/shared/ui/input'
 import { Button } from '@/shared/ui/Button'
 import { Dropdown } from '@/shared/ui/dropdown/Dropdown'
+import { useNicknameCheckMutation } from '@/features/auth-join/api/use-nickname-check-mutation'
 
-import type { NicknameCheckResponse } from '@/features/auth-join/api/nickname-api'
-import { checkNickname } from '@/features/auth-join/api/nickname-api'
-
-type ApiErrorBody = {
+interface ApiErrorBody {
   detail?: string
   error_detail?: string
 }
 
-function getErrorMessage(error: unknown, fallback: string) {
+const getErrorMessage = (error: unknown, fallback: string) => {
   if (!isAxiosError<ApiErrorBody>(error)) return fallback
   return (
     error.response?.data?.detail ??
@@ -30,36 +27,21 @@ function getErrorMessage(error: unknown, fallback: string) {
   )
 }
 
-interface ExtraInfoStepProps {
+export interface ExtraInfoStepProps {
   value: JoinFormState
   onChange: (patch: Partial<JoinFormState>) => void
 }
 
-export function ExtraInfoStep({ value, onChange }: ExtraInfoStepProps) {
-  const [nicknameError, setNicknameError] = useState<string | null>(null)
+export const ExtraInfoStep = ({ value, onChange }: ExtraInfoStepProps) => {
+  const [nicknameErrorMessage, setNicknameErrorMessage] = useState<
+    string | null
+  >(null)
 
-  const canCheckNickname = useMemo(
-    () => Boolean(value.nickname) && !value.nicknameVerified,
-    [value.nickname, value.nicknameVerified]
-  )
+  const canCheckNickname = useMemo(() => {
+    return Boolean(value.nickname) && !value.nicknameVerified
+  }, [value.nickname, value.nicknameVerified])
 
-  const checkNicknameMut = useMutation<NicknameCheckResponse, unknown, void>({
-    mutationFn: async () => checkNickname(value.nickname),
-    onSuccess: (data) => {
-      onChange({
-        nicknameVerified: true,
-        nicknameCheckToken: data.check_token,
-      })
-      setNicknameError(null)
-      toast.success(data.message || '사용 가능한 닉네임입니다.')
-    },
-    onError: (e: unknown) => {
-      onChange({ nicknameVerified: false, nicknameCheckToken: '' })
-      const msg = getErrorMessage(e, '이미 사용 중인 닉네임입니다.')
-      setNicknameError(msg)
-      toast.error(msg)
-    },
-  })
+  const nicknameCheckMutation = useNicknameCheckMutation(value.nickname)
 
   const today = useMemo(() => new Date().toISOString().slice(0, 10), [])
 
@@ -67,36 +49,58 @@ export function ExtraInfoStep({ value, onChange }: ExtraInfoStepProps) {
     <div className="flex flex-col gap-4">
       <div>
         <label className="text-sm">닉네임</label>
+
         <div className="mt-1 flex gap-2">
           <Input
             value={value.nickname}
-            onChange={(e) => {
-              setNicknameError(null)
+            onChange={(event) => {
+              setNicknameErrorMessage(null)
               onChange({
-                nickname: e.target.value,
+                nickname: event.target.value,
                 nicknameVerified: false,
                 nicknameCheckToken: '',
               })
             }}
             placeholder="닉네임을 입력해 주세요"
           />
+
           <Button
             type="button"
             variant="outline"
-            disabled={!canCheckNickname || checkNicknameMut.isPending}
-            onClick={() => checkNicknameMut.mutate()}
+            disabled={!canCheckNickname || nicknameCheckMutation.isPending}
+            onClick={async () => {
+              try {
+                const data = await nicknameCheckMutation.mutateAsync()
+                onChange({
+                  nicknameVerified: true,
+                  nicknameCheckToken: data.check_token,
+                })
+                setNicknameErrorMessage(null)
+                toast.success(data.message || '사용 가능한 닉네임입니다.')
+              } catch (error: unknown) {
+                onChange({ nicknameVerified: false, nicknameCheckToken: '' })
+                const message = getErrorMessage(
+                  error,
+                  '이미 사용 중인 닉네임입니다.'
+                )
+                setNicknameErrorMessage(message)
+                toast.error(message)
+              }
+            }}
           >
             중복확인
           </Button>
         </div>
 
-        {value.nicknameVerified && !nicknameError && (
+        {value.nicknameVerified && !nicknameErrorMessage && (
           <p className="text-brand-green mt-1 text-xs">
             사용 가능한 닉네임입니다.
           </p>
         )}
-        {nicknameError && (
-          <p className="text-brand-error mt-1 text-xs">{nicknameError}</p>
+        {nicknameErrorMessage && (
+          <p className="text-brand-error mt-1 text-xs">
+            {nicknameErrorMessage}
+          </p>
         )}
       </div>
 
@@ -107,7 +111,7 @@ export function ExtraInfoStep({ value, onChange }: ExtraInfoStepProps) {
             type="date"
             value={value.birth}
             max={today}
-            onChange={(e) => onChange({ birth: e.target.value })}
+            onChange={(event) => onChange({ birth: event.target.value })}
           />
         </div>
       </div>
@@ -117,7 +121,9 @@ export function ExtraInfoStep({ value, onChange }: ExtraInfoStepProps) {
         <div className="mt-1">
           <Dropdown
             value={value.gender || undefined}
-            onValueChange={(v) => onChange({ gender: v as GenderUI })}
+            onValueChange={(selectedValue) =>
+              onChange({ gender: selectedValue as GenderUI })
+            }
           >
             <Dropdown.Trigger size="md">
               <Dropdown.Value placeholder="성별을 선택해 주세요" />

--- a/src/features/auth-join/ui/ExtraInfoStep.tsx
+++ b/src/features/auth-join/ui/ExtraInfoStep.tsx
@@ -1,11 +1,34 @@
 'use client'
 
+import { useMutation } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
 import type {
   GenderUI,
   JoinFormState,
 } from '@/features/auth-join/ui/JoinFunnel'
 import { Input } from '@/shared/ui/input'
+import { Button } from '@/shared/ui/Button'
 import { Dropdown } from '@/shared/ui/dropdown/Dropdown'
+
+import type { NicknameCheckResponse } from '@/features/auth-join/api/nickname-api'
+import { checkNickname } from '@/features/auth-join/api/nickname-api'
+
+type ApiErrorBody = {
+  detail?: string
+  error_detail?: string
+}
+
+function getErrorMessage(error: unknown, fallback: string) {
+  if (!isAxiosError<ApiErrorBody>(error)) return fallback
+  return (
+    error.response?.data?.detail ??
+    error.response?.data?.error_detail ??
+    fallback
+  )
+}
 
 interface ExtraInfoStepProps {
   value: JoinFormState
@@ -13,32 +36,99 @@ interface ExtraInfoStepProps {
 }
 
 export function ExtraInfoStep({ value, onChange }: ExtraInfoStepProps) {
+  const [nicknameError, setNicknameError] = useState<string | null>(null)
+
+  const canCheckNickname = useMemo(
+    () => Boolean(value.nickname) && !value.nicknameVerified,
+    [value.nickname, value.nicknameVerified]
+  )
+
+  const checkNicknameMut = useMutation<NicknameCheckResponse, unknown, void>({
+    mutationFn: async () => checkNickname(value.nickname),
+    onSuccess: (data) => {
+      onChange({
+        nicknameVerified: true,
+        nicknameCheckToken: data.check_token,
+      })
+      setNicknameError(null)
+      toast.success(data.message || '사용 가능한 닉네임입니다.')
+    },
+    onError: (e: unknown) => {
+      onChange({ nicknameVerified: false, nicknameCheckToken: '' })
+      const msg = getErrorMessage(e, '이미 사용 중인 닉네임입니다.')
+      setNicknameError(msg)
+      toast.error(msg)
+    },
+  })
+
+  const today = useMemo(() => new Date().toISOString().slice(0, 10), [])
+
   return (
     <div className="flex flex-col gap-4">
       <div>
         <label className="text-sm">닉네임</label>
-        <Input
-          value={value.nickname}
-          onChange={(e) => onChange({ nickname: e.target.value })}
-        />
+        <div className="mt-1 flex gap-2">
+          <Input
+            value={value.nickname}
+            onChange={(e) => {
+              setNicknameError(null)
+              onChange({
+                nickname: e.target.value,
+                nicknameVerified: false,
+                nicknameCheckToken: '',
+              })
+            }}
+            placeholder="닉네임을 입력해 주세요"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!canCheckNickname || checkNicknameMut.isPending}
+            onClick={() => checkNicknameMut.mutate()}
+          >
+            중복확인
+          </Button>
+        </div>
+
+        {value.nicknameVerified && !nicknameError && (
+          <p className="text-brand-green mt-1 text-xs">
+            사용 가능한 닉네임입니다.
+          </p>
+        )}
+        {nicknameError && (
+          <p className="text-brand-error mt-1 text-xs">{nicknameError}</p>
+        )}
       </div>
 
       <div>
         <label className="text-sm">생년월일</label>
-        <Input
-          type="date"
-          value={value.birth}
-          onChange={(e) => onChange({ birth: e.target.value })}
-        />
+        <div className="mt-1">
+          <Input
+            type="date"
+            value={value.birth}
+            max={today}
+            onChange={(e) => onChange({ birth: e.target.value })}
+          />
+        </div>
       </div>
 
       <div>
         <label className="text-sm">성별</label>
+        <div className="mt-1">
+          <Dropdown
+            value={value.gender || undefined}
+            onValueChange={(v) => onChange({ gender: v as GenderUI })}
+          >
+            <Dropdown.Trigger size="md">
+              <Dropdown.Value placeholder="성별을 선택해 주세요" />
+            </Dropdown.Trigger>
 
-        <Dropdown
-          value={value.gender || undefined}
-          onValueChange={(v: string) => onChange({ gender: v as GenderUI })}
-        />
+            <Dropdown.Content>
+              <Dropdown.Item value="MALE">남성</Dropdown.Item>
+              <Dropdown.Item value="FEMALE">여성</Dropdown.Item>
+            </Dropdown.Content>
+          </Dropdown>
+        </div>
       </div>
     </div>
   )

--- a/src/features/auth-join/ui/Funnel.tsx
+++ b/src/features/auth-join/ui/Funnel.tsx
@@ -12,11 +12,14 @@ export interface FunnelProps {
   children: Array<ReactElement<StepProps>>
 }
 
-export function Step({ children }: StepProps): ReactElement {
+export const Step = ({ children }: StepProps): ReactElement => {
   return <>{children}</>
 }
 
-export function Funnel({ step, children }: FunnelProps): ReactElement | null {
+export const Funnel = ({
+  step,
+  children,
+}: FunnelProps): ReactElement | null => {
   const target = children.find((child) => child.props.name === step)
   if (!target) return null
   return <>{target.props.children}</>

--- a/src/features/auth-join/ui/JoinFunnel.tsx
+++ b/src/features/auth-join/ui/JoinFunnel.tsx
@@ -1,21 +1,21 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import { isAxiosError } from 'axios'
-import { useQueryState, parseAsStringLiteral } from 'nuqs'
+import { parseAsStringLiteral, useQueryState } from 'nuqs'
+import { toast } from 'sonner'
 
 import { Button } from '@/shared/ui/Button'
 import { Funnel, Step } from '@/features/auth-join/ui/Funnel'
-import { StartStep } from '@/features/auth-join/ui/StartStep'
-import { EmailPasswordStep } from '@/features/auth-join/ui/EmailPasswordStep'
-import { ProfileTermsStep } from '@/features/auth-join/ui/ProfileTermsStep'
-import { ExtraInfoStep } from '@/features/auth-join/ui/ExtraInfoStep'
 import { DoneStep } from '@/features/auth-join/ui/DoneStep'
-import {
-  signupEmail,
-  type SignupGender,
+import { EmailPasswordStep } from '@/features/auth-join/ui/EmailPasswordStep'
+import { ExtraInfoStep } from '@/features/auth-join/ui/ExtraInfoStep'
+import { ProfileTermsStep } from '@/features/auth-join/ui/ProfileTermsStep'
+import { StartStep } from '@/features/auth-join/ui/StartStep'
+import { useSignupEmailMutation } from '@/features/auth-join/api/use-signup-email-mutation'
+import type {
+  SignupEmailRequest,
+  SignupGender,
 } from '@/features/auth-join/api/signup-api'
 
 export type StepName =
@@ -52,6 +52,18 @@ export interface JoinFormState {
   gender: GenderUI | ''
 }
 
+interface StoredJoinState {
+  v: 1
+  step: Exclude<StepName, 'start' | 'done'>
+  form: JoinFormState
+  savedAt: number
+}
+
+interface ApiErrorBody {
+  detail?: string
+  error_detail?: string
+}
+
 const STEP_ORDER = [
   'start',
   'emailPassword',
@@ -59,6 +71,8 @@ const STEP_ORDER = [
   'extraInfo',
   'done',
 ] as const
+
+const JOIN_SESSION_KEY = 'studigo_join_funnel_v1'
 
 const INITIAL_JOIN_FORM_STATE: JoinFormState = {
   email: '',
@@ -84,18 +98,7 @@ const INITIAL_JOIN_FORM_STATE: JoinFormState = {
   gender: '',
 }
 
-const JOIN_SESSION_KEY = 'studigo_join_funnel_v1'
-
-type StoredJoinState = {
-  v: 1
-  step: Exclude<StepName, 'start' | 'done'>
-  form: JoinFormState
-  savedAt: number
-}
-
-type ApiErrorBody = { detail?: string; error_detail?: string }
-
-function getErrorMessage(error: unknown, fallback: string) {
+const getErrorMessage = (error: unknown, fallback: string) => {
   if (!isAxiosError<ApiErrorBody>(error)) return fallback
   return (
     error.response?.data?.detail ??
@@ -104,17 +107,15 @@ function getErrorMessage(error: unknown, fallback: string) {
   )
 }
 
-function toGender(value: GenderUI | ''): SignupGender | undefined {
+const stripPhone = (phone: string) => phone.replace(/\D/g, '')
+
+const toGender = (value: GenderUI | ''): SignupGender | undefined => {
   if (value === 'MALE') return 'M'
   if (value === 'FEMALE') return 'F'
   return undefined
 }
 
-function stripPhone(phone: string) {
-  return phone.replace(/\D/g, '')
-}
-
-function canGoNext(step: StepName, form: JoinFormState) {
+const canProceedStep = (step: StepName, form: JoinFormState) => {
   if (step === 'emailPassword') {
     return Boolean(
       form.email &&
@@ -125,29 +126,35 @@ function canGoNext(step: StepName, form: JoinFormState) {
       form.emailVerifyToken
     )
   }
+
   if (step === 'profileTerms') {
     return Boolean(
       form.name && form.phone && form.agree.terms && form.agree.privacy
     )
   }
+
   if (step === 'extraInfo') {
     return Boolean(
-      form.nickname && form.birth && form.gender && form.nicknameVerified
+      form.nickname &&
+      form.birth &&
+      form.gender &&
+      form.nicknameVerified &&
+      form.nicknameCheckToken
     )
   }
+
   return false
 }
 
-function maxAllowedStep(
+const getAllowedStep = (
   form: JoinFormState
-): Exclude<StepName, 'start' | 'done'> {
-  if (!canGoNext('emailPassword', form)) return 'emailPassword'
-  if (!canGoNext('profileTerms', form)) return 'profileTerms'
-  if (!canGoNext('extraInfo', form)) return 'extraInfo'
+): Exclude<StepName, 'start' | 'done'> => {
+  if (!canProceedStep('emailPassword', form)) return 'emailPassword'
+  if (!canProceedStep('profileTerms', form)) return 'profileTerms'
   return 'extraInfo'
 }
 
-function loadStored(): StoredJoinState | null {
+const loadStoredJoinState = (): StoredJoinState | null => {
   try {
     const raw = sessionStorage.getItem(JOIN_SESSION_KEY)
     if (!raw) return null
@@ -160,38 +167,32 @@ function loadStored(): StoredJoinState | null {
   }
 }
 
-function saveStored(step: StoredJoinState['step'], form: JoinFormState) {
+const saveStoredJoinState = (
+  step: StoredJoinState['step'],
+  form: JoinFormState
+) => {
   const payload: StoredJoinState = { v: 1, step, form, savedAt: Date.now() }
   sessionStorage.setItem(JOIN_SESSION_KEY, JSON.stringify(payload))
 }
 
-function clearStored() {
+const clearStoredJoinState = () => {
   sessionStorage.removeItem(JOIN_SESSION_KEY)
 }
 
-function getNavigationType():
-  | 'reload'
-  | 'navigate'
-  | 'back_forward'
-  | 'prerender'
-  | 'unknown' {
-  const entry = performance.getEntriesByType('navigation')[0] as
-    | PerformanceNavigationTiming
-    | undefined
-  return entry?.type ?? 'unknown'
-}
-
-export function JoinFunnel() {
+export const JoinFunnel = () => {
   const stepParser = useMemo(
     () => parseAsStringLiteral(STEP_ORDER).withDefault('start'),
     []
   )
+
   const [stepParam, setStepParam] = useQueryState('step', stepParser)
   const currentStep = (stepParam ?? 'start') as StepName
 
   const [form, setForm] = useState<JoinFormState>(INITIAL_JOIN_FORM_STATE)
+
   const [isHydrated, setIsHydrated] = useState(false)
-  const didInit = useRef(false)
+
+  const isSubmittingRef = useRef(false)
 
   const updateJoinForm = (patch: Partial<JoinFormState>) => {
     setForm((prev) => ({ ...prev, ...patch }))
@@ -205,6 +206,7 @@ export function JoinFunnel() {
           agree: { all: value, terms: value, privacy: value, marketing: value },
         }
       }
+
       const nextAgree = { ...prev.agree, [key]: value }
       return {
         ...prev,
@@ -216,35 +218,35 @@ export function JoinFunnel() {
     })
   }
 
-  useEffect(() => {
-    if (didInit.current) return
-    didInit.current = true
+  const resetToStart = () => {
+    clearStoredJoinState()
+    setForm(INITIAL_JOIN_FORM_STATE)
+    setStepParam('start', { history: 'replace' })
+  }
 
-    const navType = getNavigationType()
-    const stored = loadStored()
+  useEffect(() => {
+    const stored = loadStoredJoinState()
 
     if (currentStep === 'start') {
-      clearStored()
+      clearStoredJoinState()
       setForm(INITIAL_JOIN_FORM_STATE)
       setIsHydrated(true)
       return
     }
 
-    if (navType === 'reload' && stored) {
+    if (stored) {
       setForm(stored.form)
 
-      const allowed = maxAllowedStep(stored.form)
-      const desired =
-        STEP_ORDER.indexOf(stored.step) > STEP_ORDER.indexOf(allowed)
-          ? allowed
-          : stored.step
+      const allowed = getAllowedStep(stored.form)
+      const storedIndex = STEP_ORDER.indexOf(stored.step)
+      const allowedIndex = STEP_ORDER.indexOf(allowed)
 
-      setStepParam(desired, { history: 'replace' })
+      const normalizedStep = storedIndex > allowedIndex ? allowed : stored.step
+      setStepParam(normalizedStep, { history: 'replace' })
       setIsHydrated(true)
       return
     }
 
-    clearStored()
     setForm(INITIAL_JOIN_FORM_STATE)
     setStepParam('start', { history: 'replace' })
     setIsHydrated(true)
@@ -256,92 +258,102 @@ export function JoinFunnel() {
     if (!isHydrated) return
     if (currentStep === 'start' || currentStep === 'done') return
 
-    const allowed = maxAllowedStep(form)
+    const allowed = getAllowedStep(form)
+    const currentIndex = STEP_ORDER.indexOf(currentStep)
+    const allowedIndex = STEP_ORDER.indexOf(allowed)
+
     const normalizedStep =
-      STEP_ORDER.indexOf(currentStep) > STEP_ORDER.indexOf(allowed)
+      currentIndex > allowedIndex
         ? allowed
         : (currentStep as StoredJoinState['step'])
 
-    saveStored(normalizedStep, form)
-  }, [currentStep, form, isHydrated])
+    saveStoredJoinState(normalizedStep, form)
+  }, [isHydrated, currentStep, form])
 
   useEffect(() => {
     if (!isHydrated) return
     if (currentStep === 'start' || currentStep === 'done') return
 
-    const allowed = maxAllowedStep(form)
-    const curIdx = STEP_ORDER.indexOf(currentStep)
-    const allowedIdx = STEP_ORDER.indexOf(allowed)
-    if (curIdx > allowedIdx) {
+    const allowed = getAllowedStep(form)
+    const currentIndex = STEP_ORDER.indexOf(currentStep)
+    const allowedIndex = STEP_ORDER.indexOf(allowed)
+
+    if (currentIndex > allowedIndex) {
       setStepParam(allowed, { history: 'replace' })
       toast.message('이전 단계 입력이 필요합니다.')
     }
-  }, [currentStep, form, setStepParam, isHydrated])
+  }, [isHydrated, currentStep, form, setStepParam])
 
-  useEffect(() => {
-    return () => {
-      clearStored()
-    }
-  }, [])
-
-  const goStartAndClear = () => {
-    clearStored()
-    setForm(INITIAL_JOIN_FORM_STATE)
-    setStepParam('start', { history: 'replace' })
-  }
-
-  const next = () => {
-    const idx = STEP_ORDER.indexOf(currentStep)
-    const nextStep = STEP_ORDER[Math.min(idx + 1, STEP_ORDER.length - 1)]
+  const goNext = () => {
+    const currentIndex = STEP_ORDER.indexOf(currentStep)
+    const nextStep =
+      STEP_ORDER[Math.min(currentIndex + 1, STEP_ORDER.length - 1)]
     setStepParam(nextStep, { history: 'push' })
   }
 
-  const prev = () => {
+  const goPrev = () => {
     if (currentStep === 'emailPassword') {
-      goStartAndClear()
+      resetToStart()
       return
     }
-
-    const idx = STEP_ORDER.indexOf(currentStep)
-    const prevStep = STEP_ORDER[Math.max(idx - 1, 0)]
+    const currentIndex = STEP_ORDER.indexOf(currentStep)
+    const prevStep = STEP_ORDER[Math.max(currentIndex - 1, 0)]
     setStepParam(prevStep, { history: 'push' })
   }
 
-  const signupMut = useMutation({
-    mutationFn: () =>
-      signupEmail({
-        email: form.email,
-        password: form.password,
-        password_confirm: form.passwordConfirm,
-
-        nickname: form.nickname,
-        name: form.name,
-        gender: toGender(form.gender),
-
-        phone: stripPhone(form.phone),
-        birthday: form.birth || undefined,
-
-        agree_terms: form.agree.terms,
-        agree_privacy: form.agree.privacy,
-        agree_marketing: form.agree.marketing,
-
-        email_verify_token: form.emailVerifyToken,
-        nickname_check_token: form.nicknameCheckToken,
-      }),
-    onSuccess: () => {
-      toast.success('회원가입이 완료되었습니다.')
-      clearStored()
-      setStepParam('done', { history: 'replace' })
-    },
-    onError: (error: unknown) => {
-      toast.error(getErrorMessage(error, '회원가입에 실패했습니다.'))
-    },
-  })
-
   const canProceedNext = useMemo(
-    () => canGoNext(currentStep, form),
+    () => canProceedStep(currentStep, form),
     [currentStep, form]
   )
+
+  const signupEmailMutation = useSignupEmailMutation()
+
+  const submitJoin = async () => {
+    if (signupEmailMutation.isPending) return
+    if (isSubmittingRef.current) return
+
+    if (!form.emailVerifyToken) {
+      toast.error('이메일 인증을 완료해주세요.')
+      return
+    }
+    if (!form.nicknameCheckToken) {
+      toast.error('닉네임 중복확인을 완료해주세요.')
+      return
+    }
+
+    isSubmittingRef.current = true
+
+    const payload: SignupEmailRequest = {
+      email: form.email,
+      password: form.password,
+      password_confirm: form.passwordConfirm,
+
+      nickname: form.nickname,
+      name: form.name,
+      gender: toGender(form.gender),
+
+      phone: stripPhone(form.phone),
+      birthday: form.birth || undefined,
+
+      agree_terms: form.agree.terms,
+      agree_privacy: form.agree.privacy,
+      agree_marketing: form.agree.marketing,
+
+      email_verify_token: form.emailVerifyToken,
+      nickname_check_token: form.nicknameCheckToken,
+    }
+
+    try {
+      await signupEmailMutation.mutateAsync(payload)
+      toast.success('회원가입이 완료되었습니다.')
+      clearStoredJoinState()
+      setStepParam('done', { history: 'replace' })
+    } catch (error: unknown) {
+      toast.error(getErrorMessage(error, '회원가입에 실패했습니다.'))
+    } finally {
+      isSubmittingRef.current = false
+    }
+  }
 
   return (
     <div className="w-full">
@@ -350,9 +362,12 @@ export function JoinFunnel() {
           <StartStep
             onKakao={() => {}}
             onGoogle={() => {}}
-            onStartEmail={() =>
+            onStartEmail={() => {
+              // start에서 이메일 회원가입 시작은 항상 초기화 정책 유지
+              clearStoredJoinState()
+              setForm(INITIAL_JOIN_FORM_STATE)
               setStepParam('emailPassword', { history: 'push' })
-            }
+            }}
           />
         </Step>
 
@@ -382,25 +397,26 @@ export function JoinFunnel() {
           <Button
             variant="outline"
             className="h-12 w-30"
-            disabled={signupMut.isPending}
-            onClick={prev}
+            disabled={signupEmailMutation.isPending}
+            onClick={goPrev}
           >
             이전
           </Button>
 
           <Button
             className={`h-12 flex-1 ${
-              !canProceedNext || signupMut.isPending
+              !canProceedNext || signupEmailMutation.isPending
                 ? 'pointer-events-none opacity-50'
                 : ''
             }`}
+            disabled={!canProceedNext || signupEmailMutation.isPending}
             onClick={() => {
-              if (currentStep === 'extraInfo') signupMut.mutate()
-              else next()
+              if (currentStep === 'extraInfo') void submitJoin()
+              else goNext()
             }}
           >
             {currentStep === 'extraInfo'
-              ? signupMut.isPending
+              ? signupEmailMutation.isPending
                 ? '가입 중...'
                 : '회원가입'
               : '다음'}

--- a/src/features/auth-join/ui/JoinFunnel.tsx
+++ b/src/features/auth-join/ui/JoinFunnel.tsx
@@ -115,7 +115,7 @@ const toGender = (value: GenderUI | ''): SignupGender | undefined => {
   return undefined
 }
 
-const canProceedStep = (step: StepName, form: JoinFormState) => {
+const canGoNext = (step: StepName, form: JoinFormState) => {
   if (step === 'emailPassword') {
     return Boolean(
       form.email &&
@@ -146,11 +146,12 @@ const canProceedStep = (step: StepName, form: JoinFormState) => {
   return false
 }
 
-const getAllowedStep = (
+const maxAllowedStep = (
   form: JoinFormState
 ): Exclude<StepName, 'start' | 'done'> => {
-  if (!canProceedStep('emailPassword', form)) return 'emailPassword'
-  if (!canProceedStep('profileTerms', form)) return 'profileTerms'
+  if (!canGoNext('emailPassword', form)) return 'emailPassword'
+  if (!canGoNext('profileTerms', form)) return 'profileTerms'
+  if (!canGoNext('extraInfo', form)) return 'extraInfo'
   return 'extraInfo'
 }
 
@@ -189,7 +190,6 @@ export const JoinFunnel = () => {
   const currentStep = (stepParam ?? 'start') as StepName
 
   const [form, setForm] = useState<JoinFormState>(INITIAL_JOIN_FORM_STATE)
-
   const [isHydrated, setIsHydrated] = useState(false)
 
   const isSubmittingRef = useRef(false)
@@ -218,7 +218,7 @@ export const JoinFunnel = () => {
     })
   }
 
-  const resetToStart = () => {
+  const goStartAndClear = () => {
     clearStoredJoinState()
     setForm(INITIAL_JOIN_FORM_STATE)
     setStepParam('start', { history: 'replace' })
@@ -237,12 +237,13 @@ export const JoinFunnel = () => {
     if (stored) {
       setForm(stored.form)
 
-      const allowed = getAllowedStep(stored.form)
-      const storedIndex = STEP_ORDER.indexOf(stored.step)
-      const allowedIndex = STEP_ORDER.indexOf(allowed)
+      const allowed = maxAllowedStep(stored.form)
+      const desired =
+        STEP_ORDER.indexOf(stored.step) > STEP_ORDER.indexOf(allowed)
+          ? allowed
+          : stored.step
 
-      const normalizedStep = storedIndex > allowedIndex ? allowed : stored.step
-      setStepParam(normalizedStep, { history: 'replace' })
+      setStepParam(desired, { history: 'replace' })
       setIsHydrated(true)
       return
     }
@@ -250,7 +251,7 @@ export const JoinFunnel = () => {
     setForm(INITIAL_JOIN_FORM_STATE)
     setStepParam('start', { history: 'replace' })
     setIsHydrated(true)
-    // 최초 마운트 시에만 세션스토리지 복구
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -258,12 +259,10 @@ export const JoinFunnel = () => {
     if (!isHydrated) return
     if (currentStep === 'start' || currentStep === 'done') return
 
-    const allowed = getAllowedStep(form)
-    const currentIndex = STEP_ORDER.indexOf(currentStep)
-    const allowedIndex = STEP_ORDER.indexOf(allowed)
+    const allowed = maxAllowedStep(form)
 
     const normalizedStep =
-      currentIndex > allowedIndex
+      STEP_ORDER.indexOf(currentStep) > STEP_ORDER.indexOf(allowed)
         ? allowed
         : (currentStep as StoredJoinState['step'])
 
@@ -274,7 +273,7 @@ export const JoinFunnel = () => {
     if (!isHydrated) return
     if (currentStep === 'start' || currentStep === 'done') return
 
-    const allowed = getAllowedStep(form)
+    const allowed = maxAllowedStep(form)
     const currentIndex = STEP_ORDER.indexOf(currentStep)
     const allowedIndex = STEP_ORDER.indexOf(allowed)
 
@@ -284,16 +283,16 @@ export const JoinFunnel = () => {
     }
   }, [isHydrated, currentStep, form, setStepParam])
 
-  const goNext = () => {
+  const next = () => {
     const currentIndex = STEP_ORDER.indexOf(currentStep)
     const nextStep =
       STEP_ORDER[Math.min(currentIndex + 1, STEP_ORDER.length - 1)]
     setStepParam(nextStep, { history: 'push' })
   }
 
-  const goPrev = () => {
+  const prev = () => {
     if (currentStep === 'emailPassword') {
-      resetToStart()
+      goStartAndClear()
       return
     }
     const currentIndex = STEP_ORDER.indexOf(currentStep)
@@ -302,24 +301,15 @@ export const JoinFunnel = () => {
   }
 
   const canProceedNext = useMemo(
-    () => canProceedStep(currentStep, form),
+    () => canGoNext(currentStep, form),
     [currentStep, form]
   )
 
   const signupEmailMutation = useSignupEmailMutation()
 
-  const submitJoin = async () => {
+  const onClickSubmit = async () => {
     if (signupEmailMutation.isPending) return
     if (isSubmittingRef.current) return
-
-    if (!form.emailVerifyToken) {
-      toast.error('이메일 인증을 완료해주세요.')
-      return
-    }
-    if (!form.nicknameCheckToken) {
-      toast.error('닉네임 중복확인을 완료해주세요.')
-      return
-    }
 
     isSubmittingRef.current = true
 
@@ -349,6 +339,7 @@ export const JoinFunnel = () => {
       clearStoredJoinState()
       setStepParam('done', { history: 'replace' })
     } catch (error: unknown) {
+      console.error('[signup error]', error)
       toast.error(getErrorMessage(error, '회원가입에 실패했습니다.'))
     } finally {
       isSubmittingRef.current = false
@@ -363,7 +354,6 @@ export const JoinFunnel = () => {
             onKakao={() => {}}
             onGoogle={() => {}}
             onStartEmail={() => {
-              // start에서 이메일 회원가입 시작은 항상 초기화 정책 유지
               clearStoredJoinState()
               setForm(INITIAL_JOIN_FORM_STATE)
               setStepParam('emailPassword', { history: 'push' })
@@ -398,21 +388,17 @@ export const JoinFunnel = () => {
             variant="outline"
             className="h-12 w-30"
             disabled={signupEmailMutation.isPending}
-            onClick={goPrev}
+            onClick={prev}
           >
             이전
           </Button>
 
           <Button
-            className={`h-12 flex-1 ${
-              !canProceedNext || signupEmailMutation.isPending
-                ? 'pointer-events-none opacity-50'
-                : ''
-            }`}
+            className="h-12 flex-1"
             disabled={!canProceedNext || signupEmailMutation.isPending}
             onClick={() => {
-              if (currentStep === 'extraInfo') void submitJoin()
-              else goNext()
+              if (currentStep === 'extraInfo') void onClickSubmit()
+              else next()
             }}
           >
             {currentStep === 'extraInfo'

--- a/src/features/auth-join/ui/JoinFunnel.tsx
+++ b/src/features/auth-join/ui/JoinFunnel.tsx
@@ -1,15 +1,22 @@
 'use client'
 
-import { useMemo, useState } from 'react'
-import { Button } from '@/shared/ui/Button'
+import { useEffect, useMemo, useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { isAxiosError } from 'axios'
+import { useQueryState, parseAsStringLiteral } from 'nuqs'
 
-import { useFunnel } from '@/features/auth-join/hooks/useFunnel'
+import { Button } from '@/shared/ui/Button'
 import { Funnel, Step } from '@/features/auth-join/ui/Funnel'
 import { StartStep } from '@/features/auth-join/ui/StartStep'
 import { EmailPasswordStep } from '@/features/auth-join/ui/EmailPasswordStep'
 import { ProfileTermsStep } from '@/features/auth-join/ui/ProfileTermsStep'
-import { DoneStep } from '@/features/auth-join/ui/DoneStep'
 import { ExtraInfoStep } from '@/features/auth-join/ui/ExtraInfoStep'
+import { DoneStep } from '@/features/auth-join/ui/DoneStep'
+import {
+  signupEmail,
+  type SignupGender,
+} from '@/features/auth-join/api/signup-api'
 
 export type StepName =
   | 'start'
@@ -18,23 +25,34 @@ export type StepName =
   | 'extraInfo'
   | 'done'
 
-export type AgreeKey = 'all' | 'terms' | 'marketing'
+export type AgreeKey = 'all' | 'terms' | 'privacy' | 'marketing'
+export type GenderUI = 'MALE' | 'FEMALE'
 
 export interface JoinFormState {
   email: string
   password: string
   passwordConfirm: string
 
+  emailCheckToken: string
+  emailRequestId: string
+  emailCode: string
+  emailVerified: boolean
+  emailVerifyToken: string
+
   name: string
   phone: string
+
   agree: Record<AgreeKey, boolean>
 
   nickname: string
+  nicknameVerified: boolean
+  nicknameCheckToken: string
+
   birth: string
-  gender: string
+  gender: GenderUI | ''
 }
 
-const STEP_ORDER: readonly StepName[] = [
+const STEP_ORDER = [
   'start',
   'emailPassword',
   'profileTerms',
@@ -46,61 +64,244 @@ const INITIAL_JOIN_FORM_STATE: JoinFormState = {
   email: '',
   password: '',
   passwordConfirm: '',
+
+  emailCheckToken: '',
+  emailRequestId: '',
+  emailCode: '',
+  emailVerified: false,
+  emailVerifyToken: '',
+
   name: '',
   phone: '',
-  agree: { all: false, terms: false, marketing: false },
+
+  agree: { all: false, terms: false, privacy: false, marketing: false },
+
   nickname: '',
+  nicknameVerified: false,
+  nicknameCheckToken: '',
+
   birth: '',
   gender: '',
 }
 
-export function JoinFunnel() {
-  const { currentStep, setStep, next, prev } = useFunnel<StepName>(
-    STEP_ORDER,
-    'start'
+const JOIN_SESSION_KEY = 'studigo_join_funnel_v1'
+
+type StoredJoinState = {
+  v: 1
+  step: StepName
+  form: JoinFormState
+  savedAt: number
+}
+
+function loadStoredJoinState(): StoredJoinState | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = sessionStorage.getItem(JOIN_SESSION_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as StoredJoinState
+    if (parsed?.v !== 1) return null
+    if (!parsed.form || !parsed.step) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function saveStoredJoinState(next: StoredJoinState) {
+  if (typeof window === 'undefined') return
+  sessionStorage.setItem(JOIN_SESSION_KEY, JSON.stringify(next))
+}
+
+function clearStoredJoinState() {
+  if (typeof window === 'undefined') return
+  sessionStorage.removeItem(JOIN_SESSION_KEY)
+}
+
+type ApiErrorBody = {
+  detail?: string
+  error_detail?: string
+}
+
+function getErrorMessage(error: unknown, fallback: string) {
+  if (!isAxiosError<ApiErrorBody>(error)) return fallback
+  return (
+    error.response?.data?.detail ??
+    error.response?.data?.error_detail ??
+    fallback
   )
+}
+
+function toGender(value: GenderUI | ''): SignupGender | undefined {
+  if (value === 'MALE') return 'M'
+  if (value === 'FEMALE') return 'F'
+  return undefined
+}
+
+function stripPhone(phone: string) {
+  return phone.replace(/\D/g, '')
+}
+
+function canGoNext(step: StepName, form: JoinFormState) {
+  if (step === 'emailPassword') {
+    return Boolean(
+      form.email &&
+      form.password &&
+      form.passwordConfirm &&
+      form.password === form.passwordConfirm &&
+      form.emailVerified &&
+      form.emailVerifyToken
+    )
+  }
+
+  if (step === 'profileTerms') {
+    return Boolean(
+      form.name && form.phone && form.agree.terms && form.agree.privacy
+    )
+  }
+
+  if (step === 'extraInfo') {
+    return Boolean(
+      form.nickname && form.birth && form.gender && form.nicknameVerified
+    )
+  }
+
+  return false
+}
+
+function maxAllowedStep(form: JoinFormState): StepName {
+  if (!canGoNext('emailPassword', form)) return 'emailPassword'
+  if (!canGoNext('profileTerms', form)) return 'profileTerms'
+  if (!canGoNext('extraInfo', form)) return 'extraInfo'
+  return 'extraInfo'
+}
+
+export function JoinFunnel() {
+  const stepParser = useMemo(
+    () => parseAsStringLiteral(STEP_ORDER).withDefault('start'),
+    []
+  )
+
+  const [stepParam, setStepParam] = useQueryState('step', stepParser)
+  const currentStep = (stepParam ?? 'start') as StepName
+
   const [form, setForm] = useState<JoinFormState>(INITIAL_JOIN_FORM_STATE)
 
-  const updateJoinForm = (nextValue: Partial<JoinFormState>) =>
-    setForm((prevValue) => ({ ...prevValue, ...nextValue }))
+  const updateJoinForm = (patch: Partial<JoinFormState>) => {
+    setForm((prev) => ({ ...prev, ...patch }))
+  }
 
   const updateAgreement = (key: AgreeKey, value: boolean) => {
-    setForm((prevValue) => {
+    setForm((prev) => {
       if (key === 'all') {
         return {
-          ...prevValue,
-          agree: { all: value, terms: value, marketing: value },
+          ...prev,
+          agree: { all: value, terms: value, privacy: value, marketing: value },
         }
       }
 
-      const nextAgree = { ...prevValue.agree, [key]: value }
+      const nextAgree = { ...prev.agree, [key]: value }
       return {
-        ...prevValue,
+        ...prev,
         agree: {
           ...nextAgree,
-          all: nextAgree.terms && nextAgree.marketing,
+          all: nextAgree.terms && nextAgree.privacy && nextAgree.marketing,
         },
       }
     })
   }
 
   const resetFormAndGoStart = () => {
+    clearStoredJoinState()
     setForm(INITIAL_JOIN_FORM_STATE)
-    setStep('start')
+    setStepParam('start', { history: 'replace' })
   }
 
-  const canProceedNext = useMemo(() => {
-    if (currentStep === 'emailPassword') {
-      return Boolean(form.email && form.password && form.passwordConfirm)
+  const canProceedNext = useMemo(
+    () => canGoNext(currentStep, form),
+    [currentStep, form]
+  )
+
+  useEffect(() => {
+    if (currentStep === 'start') return
+
+    const stored = loadStoredJoinState()
+    if (!stored) return
+
+    setForm(stored.form)
+
+    if (stored.step && stored.step !== currentStep) {
+      setStepParam(stored.step, { history: 'replace' })
     }
-    if (currentStep === 'profileTerms') {
-      return Boolean(form.name && form.phone && form.agree.terms)
-    }
-    if (currentStep === 'extraInfo') {
-      return Boolean(form.nickname && form.birth && form.gender)
-    }
-    return false
+    // 최초 마운트 시에만 세션스토리지 복구
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (currentStep === 'start' || currentStep === 'done') return
+
+    saveStoredJoinState({
+      v: 1,
+      step: currentStep,
+      form,
+      savedAt: Date.now(),
+    })
   }, [currentStep, form])
+
+  useEffect(() => {
+    if (currentStep === 'start' || currentStep === 'done') return
+
+    const allowed = maxAllowedStep(form)
+    const curIdx = STEP_ORDER.indexOf(currentStep)
+    const allowedIdx = STEP_ORDER.indexOf(allowed)
+
+    if (curIdx > allowedIdx) {
+      setStepParam(allowed, { history: 'replace' })
+      toast.message('이전 단계 입력이 필요합니다.')
+    }
+  }, [currentStep, form, setStepParam])
+
+  const next = () => {
+    const idx = STEP_ORDER.indexOf(currentStep)
+    const nextStep = STEP_ORDER[Math.min(idx + 1, STEP_ORDER.length - 1)]
+    setStepParam(nextStep, { history: 'push' })
+  }
+
+  const prev = () => {
+    const idx = STEP_ORDER.indexOf(currentStep)
+    const prevStep = STEP_ORDER[Math.max(idx - 1, 0)]
+    setStepParam(prevStep, { history: 'push' })
+  }
+
+  const signupMut = useMutation({
+    mutationFn: () =>
+      signupEmail({
+        email: form.email,
+        password: form.password,
+        password_confirm: form.passwordConfirm,
+
+        nickname: form.nickname,
+        name: form.name,
+        gender: toGender(form.gender),
+
+        phone: stripPhone(form.phone),
+        birthday: form.birth || undefined,
+
+        agree_terms: form.agree.terms,
+        agree_privacy: form.agree.privacy,
+        agree_marketing: form.agree.marketing,
+
+        email_verify_token: form.emailVerifyToken,
+        nickname_check_token: form.nicknameCheckToken,
+      }),
+    onSuccess: () => {
+      toast.success('회원가입이 완료되었습니다.')
+      clearStoredJoinState()
+      setStepParam('done', { history: 'replace' })
+    },
+    onError: (error: unknown) => {
+      toast.error(getErrorMessage(error, '회원가입에 실패했습니다.'))
+    },
+  })
 
   return (
     <div className="w-full">
@@ -110,8 +311,9 @@ export function JoinFunnel() {
             onKakao={() => {}}
             onGoogle={() => {}}
             onStartEmail={() => {
+              clearStoredJoinState()
               setForm(INITIAL_JOIN_FORM_STATE)
-              setStep('emailPassword')
+              setStepParam('emailPassword', { history: 'push' })
             }}
           />
         </Step>
@@ -142,6 +344,7 @@ export function JoinFunnel() {
           <Button
             variant="outline"
             className="h-12 w-30"
+            disabled={signupMut.isPending}
             onClick={() => {
               if (currentStep === 'emailPassword') resetFormAndGoStart()
               else prev()
@@ -151,13 +354,21 @@ export function JoinFunnel() {
           </Button>
 
           <Button
-            className={`h-12 flex-1 ${!canProceedNext ? 'pointer-events-none opacity-50' : ''}`}
+            className={`h-12 flex-1 ${
+              !canProceedNext || signupMut.isPending
+                ? 'pointer-events-none opacity-50'
+                : ''
+            }`}
             onClick={() => {
-              if (currentStep === 'extraInfo') setStep('done')
+              if (currentStep === 'extraInfo') signupMut.mutate()
               else next()
             }}
           >
-            {currentStep === 'extraInfo' ? '회원가입' : '다음'}
+            {currentStep === 'extraInfo'
+              ? signupMut.isPending
+                ? '가입 중...'
+                : '회원가입'
+              : '다음'}
           </Button>
         </div>
       )}

--- a/src/features/auth-join/ui/JoinFunnel.tsx
+++ b/src/features/auth-join/ui/JoinFunnel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { isAxiosError } from 'axios'
@@ -88,39 +88,12 @@ const JOIN_SESSION_KEY = 'studigo_join_funnel_v1'
 
 type StoredJoinState = {
   v: 1
-  step: StepName
+  step: Exclude<StepName, 'start' | 'done'>
   form: JoinFormState
   savedAt: number
 }
 
-function loadStoredJoinState(): StoredJoinState | null {
-  if (typeof window === 'undefined') return null
-  try {
-    const raw = sessionStorage.getItem(JOIN_SESSION_KEY)
-    if (!raw) return null
-    const parsed = JSON.parse(raw) as StoredJoinState
-    if (parsed?.v !== 1) return null
-    if (!parsed.form || !parsed.step) return null
-    return parsed
-  } catch {
-    return null
-  }
-}
-
-function saveStoredJoinState(next: StoredJoinState) {
-  if (typeof window === 'undefined') return
-  sessionStorage.setItem(JOIN_SESSION_KEY, JSON.stringify(next))
-}
-
-function clearStoredJoinState() {
-  if (typeof window === 'undefined') return
-  sessionStorage.removeItem(JOIN_SESSION_KEY)
-}
-
-type ApiErrorBody = {
-  detail?: string
-  error_detail?: string
-}
+type ApiErrorBody = { detail?: string; error_detail?: string }
 
 function getErrorMessage(error: unknown, fallback: string) {
   if (!isAxiosError<ApiErrorBody>(error)) return fallback
@@ -152,27 +125,60 @@ function canGoNext(step: StepName, form: JoinFormState) {
       form.emailVerifyToken
     )
   }
-
   if (step === 'profileTerms') {
     return Boolean(
       form.name && form.phone && form.agree.terms && form.agree.privacy
     )
   }
-
   if (step === 'extraInfo') {
     return Boolean(
       form.nickname && form.birth && form.gender && form.nicknameVerified
     )
   }
-
   return false
 }
 
-function maxAllowedStep(form: JoinFormState): StepName {
+function maxAllowedStep(
+  form: JoinFormState
+): Exclude<StepName, 'start' | 'done'> {
   if (!canGoNext('emailPassword', form)) return 'emailPassword'
   if (!canGoNext('profileTerms', form)) return 'profileTerms'
   if (!canGoNext('extraInfo', form)) return 'extraInfo'
   return 'extraInfo'
+}
+
+function loadStored(): StoredJoinState | null {
+  try {
+    const raw = sessionStorage.getItem(JOIN_SESSION_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as StoredJoinState
+    if (parsed?.v !== 1) return null
+    if (!parsed.form || !parsed.step) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function saveStored(step: StoredJoinState['step'], form: JoinFormState) {
+  const payload: StoredJoinState = { v: 1, step, form, savedAt: Date.now() }
+  sessionStorage.setItem(JOIN_SESSION_KEY, JSON.stringify(payload))
+}
+
+function clearStored() {
+  sessionStorage.removeItem(JOIN_SESSION_KEY)
+}
+
+function getNavigationType():
+  | 'reload'
+  | 'navigate'
+  | 'back_forward'
+  | 'prerender'
+  | 'unknown' {
+  const entry = performance.getEntriesByType('navigation')[0] as
+    | PerformanceNavigationTiming
+    | undefined
+  return entry?.type ?? 'unknown'
 }
 
 export function JoinFunnel() {
@@ -180,11 +186,12 @@ export function JoinFunnel() {
     () => parseAsStringLiteral(STEP_ORDER).withDefault('start'),
     []
   )
-
   const [stepParam, setStepParam] = useQueryState('step', stepParser)
   const currentStep = (stepParam ?? 'start') as StepName
 
   const [form, setForm] = useState<JoinFormState>(INITIAL_JOIN_FORM_STATE)
+  const [isHydrated, setIsHydrated] = useState(false)
+  const didInit = useRef(false)
 
   const updateJoinForm = (patch: Partial<JoinFormState>) => {
     setForm((prev) => ({ ...prev, ...patch }))
@@ -198,7 +205,6 @@ export function JoinFunnel() {
           agree: { all: value, terms: value, privacy: value, marketing: value },
         }
       }
-
       const nextAgree = { ...prev.agree, [key]: value }
       return {
         ...prev,
@@ -210,55 +216,79 @@ export function JoinFunnel() {
     })
   }
 
-  const resetFormAndGoStart = () => {
-    clearStoredJoinState()
+  useEffect(() => {
+    if (didInit.current) return
+    didInit.current = true
+
+    const navType = getNavigationType()
+    const stored = loadStored()
+
+    if (currentStep === 'start') {
+      clearStored()
+      setForm(INITIAL_JOIN_FORM_STATE)
+      setIsHydrated(true)
+      return
+    }
+
+    if (navType === 'reload' && stored) {
+      setForm(stored.form)
+
+      const allowed = maxAllowedStep(stored.form)
+      const desired =
+        STEP_ORDER.indexOf(stored.step) > STEP_ORDER.indexOf(allowed)
+          ? allowed
+          : stored.step
+
+      setStepParam(desired, { history: 'replace' })
+      setIsHydrated(true)
+      return
+    }
+
+    clearStored()
     setForm(INITIAL_JOIN_FORM_STATE)
     setStepParam('start', { history: 'replace' })
-  }
-
-  const canProceedNext = useMemo(
-    () => canGoNext(currentStep, form),
-    [currentStep, form]
-  )
-
-  useEffect(() => {
-    if (currentStep === 'start') return
-
-    const stored = loadStoredJoinState()
-    if (!stored) return
-
-    setForm(stored.form)
-
-    if (stored.step && stored.step !== currentStep) {
-      setStepParam(stored.step, { history: 'replace' })
-    }
+    setIsHydrated(true)
     // 최초 마운트 시에만 세션스토리지 복구
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {
+    if (!isHydrated) return
     if (currentStep === 'start' || currentStep === 'done') return
 
-    saveStoredJoinState({
-      v: 1,
-      step: currentStep,
-      form,
-      savedAt: Date.now(),
-    })
-  }, [currentStep, form])
+    const allowed = maxAllowedStep(form)
+    const normalizedStep =
+      STEP_ORDER.indexOf(currentStep) > STEP_ORDER.indexOf(allowed)
+        ? allowed
+        : (currentStep as StoredJoinState['step'])
+
+    saveStored(normalizedStep, form)
+  }, [currentStep, form, isHydrated])
 
   useEffect(() => {
+    if (!isHydrated) return
     if (currentStep === 'start' || currentStep === 'done') return
 
     const allowed = maxAllowedStep(form)
     const curIdx = STEP_ORDER.indexOf(currentStep)
     const allowedIdx = STEP_ORDER.indexOf(allowed)
-
     if (curIdx > allowedIdx) {
       setStepParam(allowed, { history: 'replace' })
       toast.message('이전 단계 입력이 필요합니다.')
     }
-  }, [currentStep, form, setStepParam])
+  }, [currentStep, form, setStepParam, isHydrated])
+
+  useEffect(() => {
+    return () => {
+      clearStored()
+    }
+  }, [])
+
+  const goStartAndClear = () => {
+    clearStored()
+    setForm(INITIAL_JOIN_FORM_STATE)
+    setStepParam('start', { history: 'replace' })
+  }
 
   const next = () => {
     const idx = STEP_ORDER.indexOf(currentStep)
@@ -267,6 +297,11 @@ export function JoinFunnel() {
   }
 
   const prev = () => {
+    if (currentStep === 'emailPassword') {
+      goStartAndClear()
+      return
+    }
+
     const idx = STEP_ORDER.indexOf(currentStep)
     const prevStep = STEP_ORDER[Math.max(idx - 1, 0)]
     setStepParam(prevStep, { history: 'push' })
@@ -295,13 +330,18 @@ export function JoinFunnel() {
       }),
     onSuccess: () => {
       toast.success('회원가입이 완료되었습니다.')
-      clearStoredJoinState()
+      clearStored()
       setStepParam('done', { history: 'replace' })
     },
     onError: (error: unknown) => {
       toast.error(getErrorMessage(error, '회원가입에 실패했습니다.'))
     },
   })
+
+  const canProceedNext = useMemo(
+    () => canGoNext(currentStep, form),
+    [currentStep, form]
+  )
 
   return (
     <div className="w-full">
@@ -310,11 +350,9 @@ export function JoinFunnel() {
           <StartStep
             onKakao={() => {}}
             onGoogle={() => {}}
-            onStartEmail={() => {
-              clearStoredJoinState()
-              setForm(INITIAL_JOIN_FORM_STATE)
+            onStartEmail={() =>
               setStepParam('emailPassword', { history: 'push' })
-            }}
+            }
           />
         </Step>
 
@@ -345,10 +383,7 @@ export function JoinFunnel() {
             variant="outline"
             className="h-12 w-30"
             disabled={signupMut.isPending}
-            onClick={() => {
-              if (currentStep === 'emailPassword') resetFormAndGoStart()
-              else prev()
-            }}
+            onClick={prev}
           >
             이전
           </Button>

--- a/src/features/auth-join/ui/ProfileTermsStep.tsx
+++ b/src/features/auth-join/ui/ProfileTermsStep.tsx
@@ -53,11 +53,13 @@ export function ProfileTermsStep(props: {
             inputMode="numeric"
             autoComplete="tel"
           />
+
           <Button
             type="button"
             size="reg"
             variant="secondary"
             className="h-12 w-24"
+            disabled
           >
             인증
           </Button>
@@ -75,6 +77,11 @@ export function ProfileTermsStep(props: {
           label="(필수) 서비스 이용을 위한 필수 동의사항"
           checked={formValue.agree.terms}
           onChange={(checked) => props.onToggleAgree('terms', checked)}
+        />
+        <CheckRow
+          label="(필수) 개인정보 처리방침 동의"
+          checked={formValue.agree.privacy}
+          onChange={(checked) => props.onToggleAgree('privacy', checked)}
         />
         <CheckRow
           label="(선택) 마케팅 정보 수신 동의"

--- a/src/features/auth-join/ui/ProfileTermsStep.tsx
+++ b/src/features/auth-join/ui/ProfileTermsStep.tsx
@@ -7,7 +7,7 @@ import type {
   JoinFormState,
 } from '@/features/auth-join/ui/JoinFunnel'
 
-function formatKoreanPhoneNumber(input: string) {
+const formatKoreanPhoneNumber = (input: string) => {
   const digits = input.replace(/\D/g, '').slice(0, 11)
 
   const first = digits.slice(0, 3)
@@ -19,16 +19,20 @@ function formatKoreanPhoneNumber(input: string) {
   return `${first}-${middle}-${last}`
 }
 
-export function ProfileTermsStep(props: {
+export interface ProfileTermsStepProps {
   value: JoinFormState
   onChange: (patch: Partial<JoinFormState>) => void
-  onToggleAgree: (k: AgreeKey, v: boolean) => void
-}) {
-  const formValue = props.value
+  onToggleAgree: (key: AgreeKey, value: boolean) => void
+}
 
-  const onPhoneChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const next = formatKoreanPhoneNumber(e.target.value)
-    props.onChange({ phone: next })
+export const ProfileTermsStep = ({
+  value,
+  onChange,
+  onToggleAgree,
+}: ProfileTermsStepProps) => {
+  const onPhoneChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextValue = formatKoreanPhoneNumber(event.target.value)
+    onChange({ phone: nextValue })
   }
 
   return (
@@ -37,8 +41,8 @@ export function ProfileTermsStep(props: {
         <Input
           size="sm"
           placeholder="이름을 입력해주세요."
-          value={formValue.name}
-          onChange={(e) => props.onChange({ name: e.target.value })}
+          value={value.name}
+          onChange={(event) => onChange({ name: event.target.value })}
         />
       </Field>
 
@@ -46,7 +50,7 @@ export function ProfileTermsStep(props: {
         <Input
           size="sm"
           placeholder="010-0000-0000"
-          value={formValue.phone}
+          value={value.phone}
           onChange={onPhoneChange}
           inputMode="numeric"
           autoComplete="tel"
@@ -56,53 +60,60 @@ export function ProfileTermsStep(props: {
       <div className="pt-2">
         <CheckRow
           label="전체 동의"
-          checked={formValue.agree.all}
-          onChange={(checked) => props.onToggleAgree('all', checked)}
+          checked={value.agree.all}
+          onChange={(checked) => onToggleAgree('all', checked)}
         />
         <div className="bg-brand-gray-200 my-3 h-px w-full" />
         <CheckRow
           label="(필수) 서비스 이용을 위한 필수 동의사항"
-          checked={formValue.agree.terms}
-          onChange={(checked) => props.onToggleAgree('terms', checked)}
+          checked={value.agree.terms}
+          onChange={(checked) => onToggleAgree('terms', checked)}
         />
         <CheckRow
           label="(필수) 개인정보 처리방침 동의"
-          checked={formValue.agree.privacy}
-          onChange={(checked) => props.onToggleAgree('privacy', checked)}
+          checked={value.agree.privacy}
+          onChange={(checked) => onToggleAgree('privacy', checked)}
         />
         <CheckRow
           label="(선택) 마케팅 정보 수신 동의"
-          checked={formValue.agree.marketing}
-          onChange={(checked) => props.onToggleAgree('marketing', checked)}
+          checked={value.agree.marketing}
+          onChange={(checked) => onToggleAgree('marketing', checked)}
         />
       </div>
     </div>
   )
 }
 
-function Field(props: { label: string; children: ReactNode }) {
+interface FieldProps {
+  label: string
+  children: ReactNode
+}
+
+const Field = ({ label, children }: FieldProps) => {
   return (
     <div className="space-y-1">
-      <label className="text-brand-gray-500 text-sm">{props.label}</label>
-      {props.children}
+      <label className="text-brand-gray-500 text-sm">{label}</label>
+      {children}
     </div>
   )
 }
 
-function CheckRow(props: {
+interface CheckRowProps {
   label: string
   checked: boolean
   onChange: (checked: boolean) => void
-}) {
+}
+
+const CheckRow = ({ label, checked, onChange }: CheckRowProps) => {
   return (
     <label className="flex cursor-pointer items-center gap-2 py-1 text-sm">
       <input
         type="checkbox"
         className="border-brand-gray-300 h-4 w-4 rounded"
-        checked={props.checked}
-        onChange={(e) => props.onChange(e.target.checked)}
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
       />
-      <span className="text-brand-gray-500">{props.label}</span>
+      <span className="text-brand-gray-500">{label}</span>
     </label>
   )
 }

--- a/src/features/auth-join/ui/ProfileTermsStep.tsx
+++ b/src/features/auth-join/ui/ProfileTermsStep.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { ChangeEvent, ReactNode } from 'react'
-import { Button } from '@/shared/ui/Button'
 import { Input } from '@/shared/ui/input'
 import type {
   AgreeKey,
@@ -44,26 +43,14 @@ export function ProfileTermsStep(props: {
       </Field>
 
       <Field label="전화번호">
-        <div className="flex gap-2">
-          <Input
-            size="sm"
-            placeholder="010-0000-0000"
-            value={formValue.phone}
-            onChange={onPhoneChange}
-            inputMode="numeric"
-            autoComplete="tel"
-          />
-
-          <Button
-            type="button"
-            size="reg"
-            variant="secondary"
-            className="h-12 w-24"
-            disabled
-          >
-            인증
-          </Button>
-        </div>
+        <Input
+          size="sm"
+          placeholder="010-0000-0000"
+          value={formValue.phone}
+          onChange={onPhoneChange}
+          inputMode="numeric"
+          autoComplete="tel"
+        />
       </Field>
 
       <div className="pt-2">

--- a/src/features/auth-join/ui/StartStep.tsx
+++ b/src/features/auth-join/ui/StartStep.tsx
@@ -6,11 +6,17 @@ import { Button } from '@/shared/ui/Button'
 import KakaoIcon from '@/shared/assets/kakao-icon.svg'
 import GoogleIcon from '@/shared/assets/google-icon.svg'
 
-export function StartStep(props: {
+export interface StartStepProps {
   onKakao: () => void
   onGoogle: () => void
   onStartEmail: () => void
-}) {
+}
+
+export const StartStep = ({
+  onKakao,
+  onGoogle,
+  onStartEmail,
+}: StartStepProps) => {
   return (
     <div className="space-y-3">
       <Button
@@ -18,7 +24,7 @@ export function StartStep(props: {
         size="reg"
         style={{ backgroundColor: '#FEE500', color: '#1E1919' }}
         className="w-full cursor-pointer hover:opacity-90"
-        onClick={props.onKakao}
+        onClick={onKakao}
       >
         <KakaoIcon className="mr-2 size-5 shrink-0 overflow-visible" />
         카카오로 시작하기
@@ -29,7 +35,7 @@ export function StartStep(props: {
         size="reg"
         variant="outline"
         className="hover:bg-brand-gray-100 hover:border-brand-gray-400 w-full cursor-pointer"
-        onClick={props.onGoogle}
+        onClick={onGoogle}
       >
         <GoogleIcon className="mr-2 size-5 shrink-0 overflow-visible" />
         구글로 시작하기
@@ -45,7 +51,7 @@ export function StartStep(props: {
         type="button"
         size="reg"
         className="bg-brand-black text-brand-white w-full cursor-pointer hover:opacity-90"
-        onClick={props.onStartEmail}
+        onClick={onStartEmail}
       >
         이메일로 가입
       </Button>

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -7,3 +7,5 @@ export const api = axios.create({
   },
   withCredentials: true,
 })
+
+export const apiClient = api


### PR DESCRIPTION
## #️⃣연관된 이슈

> #86 

## 📝작업 내용

> 이메일 회원가입 퍼널을 실제 API와 연동하여 전체 가입 플로우 구현
> Swagger 명세에 맞게 회원가입 요청 payload 및 인증 토큰 매핑
> 회원가입 API 201 성공 응답임에도 완료 단계로 이동하지 않던 버그 수정
> 퍼널 단계 가드 및 상태 관리 로직 정리
> 새로고침 시 단계/입력값 복구 및 중복 회원가입 요청 방지 로직 보완

## 🖼️스크린샷

> 

https://github.com/user-attachments/assets/606b76dc-1917-4200-ba0f-c87ccd2dbb20


## 💬리뷰 요구사항 (선택)

>  회원가입 API 연동 및 퍼널 완료 흐름이 적절한지 확인 부탁드립니다.
> 201 성공 응답을 기준으로 완료 처리하도록 변경한 로직이 괜찮은지 리뷰 요청드립니다.
> 퍼널 단계 가드 및 새로고침 시 상태 복구 로직에 대한 의견 부탁드립니다.

## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
