### PR TITLE
[Refactor] 웹소켓 이벤트 타입 및 페이로드 스키마 변경사항 반영

### DIFF
--- a/src/entities/message/model/useMessageCacheHandler.ts
+++ b/src/entities/message/model/useMessageCacheHandler.ts
@@ -11,7 +11,7 @@ function useMessageCacheHandler() {
 
   // NEW_MESSAGE 타입 이벤트 핸들러
   const handleNewMessage = useCallback(
-    (roomId: number | null, message: Message) => {
+    (roomId: number | null, newMessage: Message) => {
       if (!roomId) return
 
       queryClient.setQueryData<InfiniteData<ChatMessageListResponse>>(
@@ -21,13 +21,13 @@ function useMessageCacheHandler() {
 
           const newPages = [...prev.pages]
           const isExistMessage = newPages[0].messages.some(
-            (message) => message.id === message.id
+            (message) => message.id === newMessage.id
           )
           // 기존에 존재하던 메세지인지 검증 → 가장 최신 페이지에 수신한 메세지 추가
           if (isExistMessage) return prev
           newPages[0] = {
             ...newPages[0],
-            messages: [message, ...newPages[0].messages],
+            messages: [newMessage, ...newPages[0].messages],
           }
 
           return {
@@ -40,7 +40,39 @@ function useMessageCacheHandler() {
     [queryClient]
   )
 
-  return { handleNewMessage }
+  // MESSAGE_DELETED 타입 이벤트 핸들러
+  const handleMessageDeleted = useCallback(
+    (roomId: number | null, deletedMessageId: number) => {
+      if (!roomId) return
+
+      queryClient.setQueryData<InfiniteData<ChatMessageListResponse>>(
+        chatKeys.messageList(roomId),
+        (prev) => {
+          if (!prev) return prev
+
+          const newPages = prev.pages.map((page) => ({
+            ...page,
+            messages: page.messages.map((message) => {
+              if (message.id === deletedMessageId)
+                return {
+                  ...message,
+                  status: 'DELETED_BY_ADMIN' as const,
+                }
+              return message
+            }),
+          }))
+
+          return {
+            ...prev,
+            pages: newPages,
+          }
+        }
+      )
+    },
+    [queryClient]
+  )
+
+  return { handleNewMessage, handleMessageDeleted }
 }
 
 export default useMessageCacheHandler

--- a/src/entities/message/model/useMessageCacheHandler.ts
+++ b/src/entities/message/model/useMessageCacheHandler.ts
@@ -11,7 +11,7 @@ function useMessageCacheHandler() {
 
   // NEW_MESSAGE 타입 이벤트 핸들러
   const handleNewMessage = useCallback(
-    (roomId: number | null, payload: Message) => {
+    (roomId: number | null, message: Message) => {
       if (!roomId) return
 
       queryClient.setQueryData<InfiniteData<ChatMessageListResponse>>(
@@ -21,13 +21,13 @@ function useMessageCacheHandler() {
 
           const newPages = [...prev.pages]
           const isExistMessage = newPages[0].messages.some(
-            (message) => message.id === payload.id
+            (message) => message.id === message.id
           )
           // 기존에 존재하던 메세지인지 검증 → 가장 최신 페이지에 수신한 메세지 추가
           if (isExistMessage) return prev
           newPages[0] = {
             ...newPages[0],
-            messages: [payload, ...newPages[0].messages],
+            messages: [message, ...newPages[0].messages],
           }
 
           return {

--- a/src/features/chat-message-subscribe/model/schema.ts
+++ b/src/features/chat-message-subscribe/model/schema.ts
@@ -8,34 +8,36 @@ export const ChatSocketEventTypeSchema = z.enum([
 
 export type ChatSocketEventType = z.infer<typeof ChatSocketEventTypeSchema>
 
-// ---------- NEW_MESSAGE ----------
-export const ChatSocketNewMessageEventSchema = z
-  .object({
-    type: ChatSocketEventTypeSchema,
-    message: ChatMessageSchema,
-  })
-  .transform((data) => ({
-    type: data.type,
-    message: data.message,
-  }))
+export const ChatSocketEventSchema = z.discriminatedUnion('type', [
+  // ---------- NEW_MESSAGE ----------
+  z
+    .object({ type: z.literal('NEW_MESSAGE'), message: ChatMessageSchema })
+    .transform((data) => ({
+      type: data.type,
+      message: data.message,
+    })),
+  // ---------- MESSAGE_DELETED ----------
+  z
+    .object({
+      type: z.literal('MESSAGE_DELETED'),
+      room_id: z.number(),
+      message_id: z.number(),
+    })
+    .transform((data) => ({
+      type: data.type,
+      roomId: data.room_id,
+      messageId: data.message_id,
+    })),
+])
 
-export type ChatSocketNewMessageEvent = z.infer<
-  typeof ChatSocketNewMessageEventSchema
+export type ChatSocketEvent = z.infer<typeof ChatSocketEventSchema>
+
+export type ChatSocketNewMessageEvent = Extract<
+  ChatSocketEvent,
+  { type: 'NEW_MESSAGE' }
 >
 
-// ---------- MESSAGE_DELETED ----------
-export const ChatSocketMessageDeletedEventSchema = z
-  .object({
-    type: ChatSocketEventTypeSchema,
-    room_id: z.number(),
-    message_id: z.number(),
-  })
-  .transform((data) => ({
-    type: data.type,
-    roomId: data.room_id,
-    messageId: data.message_id,
-  }))
-
-export type ChatSocketMessageDeletedEvent = z.infer<
-  typeof ChatSocketMessageDeletedEventSchema
+export type ChatSocketMessageDeletedEvent = Extract<
+  ChatSocketEvent,
+  { type: 'MESSAGE_DELETED' }
 >

--- a/src/features/chat-message-subscribe/model/schema.ts
+++ b/src/features/chat-message-subscribe/model/schema.ts
@@ -1,7 +1,10 @@
 import { ChatMessageSchema } from '@/entities/message/model/schema'
 import z from 'zod'
 
-export const ChatSocketEventTypeSchema = z.enum(['NEW_MESSAGE'])
+export const ChatSocketEventTypeSchema = z.enum([
+  'NEW_MESSAGE',
+  'MESSAGE_DELETED',
+])
 
 export type ChatSocketEventType = z.infer<typeof ChatSocketEventTypeSchema>
 
@@ -18,4 +21,21 @@ export const ChatSocketNewMessageEventSchema = z
 
 export type ChatSocketNewMessageEvent = z.infer<
   typeof ChatSocketNewMessageEventSchema
+>
+
+// ---------- MESSAGE_DELETED ----------
+export const ChatSocketMessageDeletedEventSchema = z
+  .object({
+    type: ChatSocketEventTypeSchema,
+    room_id: z.number(),
+    message_id: z.number(),
+  })
+  .transform((data) => ({
+    type: data.type,
+    roomId: data.room_id,
+    messageId: data.message_id,
+  }))
+
+export type ChatSocketMessageDeletedEvent = z.infer<
+  typeof ChatSocketMessageDeletedEventSchema
 >

--- a/src/features/chat-message-subscribe/model/schema.ts
+++ b/src/features/chat-message-subscribe/model/schema.ts
@@ -5,14 +5,17 @@ export const ChatSocketEventTypeSchema = z.enum(['NEW_MESSAGE'])
 
 export type ChatSocketEventType = z.infer<typeof ChatSocketEventTypeSchema>
 
-export const ChatSocketEventSchema = z
+// ---------- NEW_MESSAGE ----------
+export const ChatSocketNewMessageEventSchema = z
   .object({
     type: ChatSocketEventTypeSchema,
-    payload: ChatMessageSchema,
+    message: ChatMessageSchema,
   })
   .transform((data) => ({
     type: data.type,
-    payload: data.payload,
+    message: data.message,
   }))
 
-export type ChatSocketEvent = z.infer<typeof ChatSocketEventSchema>
+export type ChatSocketNewMessageEvent = z.infer<
+  typeof ChatSocketNewMessageEventSchema
+>

--- a/src/features/chat-message-subscribe/model/useMessageSubscribe.ts
+++ b/src/features/chat-message-subscribe/model/useMessageSubscribe.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react'
-import { ChatSocketNewMessageEventSchema } from '@/features/chat-message-subscribe/model/schema'
+import { ChatSocketEventSchema } from '@/features/chat-message-subscribe/model/schema'
 import useMessageCacheHandler from '@/entities/message/model/useMessageCacheHandler'
 import { useChatSocketStore } from '@/features/chat-message-subscribe/model/store'
 
@@ -15,12 +15,13 @@ function useMessageSubscribe(
     (event: MessageEvent) => {
       try {
         const data = JSON.parse(event.data)
-        const parsedData = ChatSocketNewMessageEventSchema.parse(data)
-        const { type, message } = parsedData
+        const parsedData = ChatSocketEventSchema.parse(data)
+        const { type } = parsedData
 
         switch (type) {
           case 'NEW_MESSAGE':
-            handleNewMessage(roomId, message)
+            handleNewMessage(roomId, parsedData.message)
+            break
         }
       } catch (error) {
         console.error(`[Socket Error] 채팅방 번호: ${roomId}\n`, error)

--- a/src/features/chat-message-subscribe/model/useMessageSubscribe.ts
+++ b/src/features/chat-message-subscribe/model/useMessageSubscribe.ts
@@ -8,7 +8,7 @@ function useMessageSubscribe(
   accessToken: string | null
 ) {
   const { connect } = useChatSocketStore()
-  const { handleNewMessage } = useMessageCacheHandler()
+  const { handleNewMessage, handleMessageDeleted } = useMessageCacheHandler()
 
   // 수신 데이터 파싱 → 이벤트 타입에 따라 적절한 캐시 업데이트 함수 실행
   const handleSocketMessage = useCallback(
@@ -22,12 +22,15 @@ function useMessageSubscribe(
           case 'NEW_MESSAGE':
             handleNewMessage(roomId, parsedData.message)
             break
+          case 'MESSAGE_DELETED':
+            handleMessageDeleted(roomId, parsedData.messageId)
+            break
         }
       } catch (error) {
         console.error(`[Socket Error] 채팅방 번호: ${roomId}\n`, error)
       }
     },
-    [handleNewMessage, roomId]
+    [handleMessageDeleted, handleNewMessage, roomId]
   )
 
   useEffect(() => {

--- a/src/features/chat-message-subscribe/model/useMessageSubscribe.ts
+++ b/src/features/chat-message-subscribe/model/useMessageSubscribe.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react'
-import { ChatSocketEventSchema } from '@/features/chat-message-subscribe/model/schema'
+import { ChatSocketNewMessageEventSchema } from '@/features/chat-message-subscribe/model/schema'
 import useMessageCacheHandler from '@/entities/message/model/useMessageCacheHandler'
 import { useChatSocketStore } from '@/features/chat-message-subscribe/model/store'
 
@@ -15,12 +15,12 @@ function useMessageSubscribe(
     (event: MessageEvent) => {
       try {
         const data = JSON.parse(event.data)
-        const parsedData = ChatSocketEventSchema.parse(data)
-        const { type, payload } = parsedData
+        const parsedData = ChatSocketNewMessageEventSchema.parse(data)
+        const { type, message } = parsedData
 
         switch (type) {
           case 'NEW_MESSAGE':
-            handleNewMessage(roomId, payload)
+            handleNewMessage(roomId, message)
         }
       } catch (error) {
         console.error(`[Socket Error] 채팅방 번호: ${roomId}\n`, error)

--- a/src/shared/api/mocks/data/chat-data.ts
+++ b/src/shared/api/mocks/data/chat-data.ts
@@ -55,16 +55,17 @@ const ES_MESSAGE_CONTENTS = [
   'Pedí té con leche porque quería perlas, pero no traía nada. Así que me lo tomé así...',
   '¡¡¡Hoy sí que me voy a dormir temprano!!!',
 ]
+const USER_ID = 3
 
 export const MESSAGES = Array.from({ length: MESSAGE_COUNT }, (_, i) => {
-  const userId = Math.floor(Math.random() * 2) + 1
+  const userId = Math.floor(Math.random() * 10) + 1
 
   return {
     id: i + 1,
     sender_user_id: userId,
     sender: {
       id: userId,
-      nickname: userId === 1 ? '나' : '다른유저',
+      nickname: userId === USER_ID ? '나' : '다른유저',
       profile_image_url: null,
     },
     ko_content: KO_MESSAGE_CONTENTS[i % KO_MESSAGE_CONTENTS.length],
@@ -80,9 +81,9 @@ export const SOCKET_MESSAGES = Array.from(
   { length: SOCKET_MESSAGE_COUNT },
   (_, i) => ({
     id: MESSAGES.length + i + 1,
-    sender_user_id: 3,
+    sender_user_id: USER_ID + 1,
     sender: {
-      id: 3,
+      id: USER_ID + 1,
       nickname: '웹소켓',
       profile_image_url: null,
     },

--- a/src/shared/api/mocks/handlers/chat-handlers.ts
+++ b/src/shared/api/mocks/handlers/chat-handlers.ts
@@ -136,16 +136,28 @@ const url = `${protocol}://${process.env.NEXT_PUBLIC_WS_HOST}/ws/chat/rooms/:roo
 const chat = ws.link(url)
 
 const chatSocketHandlers = [
-  chat.addEventListener('connection', ({ client }) => {
+  chat.addEventListener('connection', async ({ client }) => {
     console.log('✨ 웹소켓 연결 완료!')
 
-    SOCKET_MESSAGES.forEach(async (message, index) => {
-      await new Promise((resolve) =>
-        setTimeout(resolve, 1000 * index + 1)
-      ).then(() =>
+    // 새로운 메세지
+    for (const [_, message] of SOCKET_MESSAGES.entries()) {
+      await new Promise((resolve) => setTimeout(resolve, 500)).then(() =>
         client.send(JSON.stringify({ type: 'NEW_MESSAGE', message }))
       )
-    })
+    }
+
+    // 관리자가 메세지 삭제
+    const url = client.url.toString()
+    const roomId = Number(url.split('/')[6])
+    await new Promise((resolve) => setTimeout(resolve, 1000)).then(() =>
+      client.send(
+        JSON.stringify({
+          type: 'MESSAGE_DELETED',
+          room_id: roomId,
+          message_id: 104,
+        })
+      )
+    )
 
     client.addEventListener('close', () => {
       console.log('✨ 웹소켓 연결 종료!')

--- a/src/shared/api/mocks/handlers/chat-handlers.ts
+++ b/src/shared/api/mocks/handlers/chat-handlers.ts
@@ -143,7 +143,7 @@ const chatSocketHandlers = [
       await new Promise((resolve) =>
         setTimeout(resolve, 1000 * index + 1)
       ).then(() =>
-        client.send(JSON.stringify({ type: 'NEW_MESSAGE', payload: message }))
+        client.send(JSON.stringify({ type: 'NEW_MESSAGE', message }))
       )
     })
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #95

## 📝작업 내용

> 웹소켓 이벤트 타입 및 페이로드 스키마 변경사항 반영
- 웹소켓 이벤트 타입 및 페이로드 스키마 변경사항 반영
- 웹소켓 MESSAGE_DELETED 이벤트 핸들러 추가

## 🖼️스크린샷

https://github.com/user-attachments/assets/09df7047-83c7-4b05-baff-3fd21427aff4

## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
