### PR TITLE
[Feature] 마이페이지 내정보 수정 ui 구현 (#97)

### DIFF
--- a/src/app/mypage/my-information-fix/page.tsx
+++ b/src/app/mypage/my-information-fix/page.tsx
@@ -1,0 +1,5 @@
+import { MyInformationFix } from '@/features/mypage-my-information-fix/ui/MyInformationFix'
+
+export default function Page() {
+  return <MyInformationFix />
+}

--- a/src/features/mypage-my-information-fix/ui/MyInformationFix.tsx
+++ b/src/features/mypage-my-information-fix/ui/MyInformationFix.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import * as React from 'react'
+import { useRef, useState, type ChangeEventHandler } from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 
@@ -10,43 +10,74 @@ import { cn } from '@/shared/lib/cn'
 
 type UserRole = 'user' | 'admin' | 'instructor'
 
-type MyInfoDraft = {
+interface MyInfoDraft {
   nickname: string
   marketingAgree: boolean
-  profileImage?: string | null // dataURL or null
+  profileImage?: string | null
 }
 
 const MYINFO_STORAGE_KEY = 'studigo_myinfo_draft'
 
+const getInitialDraft = (): MyInfoDraft | null => {
+  if (typeof window === 'undefined') return null
+
+  try {
+    const raw = localStorage.getItem(MYINFO_STORAGE_KEY)
+    if (!raw) return null
+
+    const parsed = JSON.parse(raw) as Partial<MyInfoDraft>
+
+    const nickname =
+      typeof parsed.nickname === 'string' ? parsed.nickname : 'fortes42'
+    const marketingAgree =
+      typeof parsed.marketingAgree === 'boolean' ? parsed.marketingAgree : true
+    const profileImage =
+      typeof parsed.profileImage === 'string' || parsed.profileImage === null
+        ? parsed.profileImage
+        : null
+
+    return { nickname, marketingAgree, profileImage }
+  } catch {
+    return null
+  }
+}
+
 export function MyInformationFix() {
   const router = useRouter()
 
-  const fileRef = React.useRef<HTMLInputElement>(null)
-  const [previewUrl, setPreviewUrl] = React.useState<string | null>(null)
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  const [draft] = useState<MyInfoDraft | null>(() => getInitialDraft())
+
+  const [previewUrl, setPreviewUrl] = useState<string | null>(
+    draft?.profileImage ?? null
+  )
 
   const userRole: UserRole = 'user' // TODO: 실제 유저 role로 교체
-  const [nickname, setNickname] = React.useState('fortes42')
+  const [nickname, setNickname] = useState(draft?.nickname ?? 'fortes42')
+  const [marketingAgree, setMarketingAgree] = useState(
+    draft?.marketingAgree ?? true
+  )
+
   const nameValue = '박진우'
   const joinedAtValue = '2026.01.08'
   const emailValue = 'forteslv42@gmail.com'
   const phoneValue = '01012345678'
-  const [marketingAgree, setMarketingAgree] = React.useState(true)
 
-  const [isPasswordEditing, setIsPasswordEditing] = React.useState(false)
+  const [isPasswordEditing, setIsPasswordEditing] = useState(false)
 
-  const [currentPassword] = React.useState('***************')
-  const [newPassword, setNewPassword] = React.useState('')
-  const [newPasswordConfirm, setNewPasswordConfirm] = React.useState('')
+  const [currentPassword] = useState('***************')
+  const [newPassword, setNewPassword] = useState('')
+  const [newPasswordConfirm, setNewPasswordConfirm] = useState('')
 
   const hasTypedNewPw = isPasswordEditing && newPassword.length > 0
-
   const isMin8 = newPassword.length >= 8
   const hasLetter = /[A-Za-z]/.test(newPassword)
   const hasNumber = /\d/.test(newPassword)
   const hasSpecial = /[^A-Za-z0-9]/.test(newPassword)
   const isComboOk = hasLetter && hasNumber && hasSpecial
 
-  const ruleTextColor = (ok: boolean) => {
+  const passwordRuleTextColor = (ok: boolean) => {
     if (!hasTypedNewPw) return 'text-brand-gray-300'
     return ok ? 'text-brand-green' : 'text-brand-main'
   }
@@ -62,26 +93,11 @@ export function MyInformationFix() {
     instructor: 'border-brand-blue',
   }[userRole]
 
-  React.useEffect(() => {
-    if (typeof window === 'undefined') return
-    try {
-      const raw = localStorage.getItem(MYINFO_STORAGE_KEY)
-      if (!raw) return
-      const saved = JSON.parse(raw) as MyInfoDraft
-
-      if (typeof saved.nickname === 'string') setNickname(saved.nickname)
-      if (typeof saved.marketingAgree === 'boolean')
-        setMarketingAgree(saved.marketingAgree)
-      if (typeof saved.profileImage === 'string' || saved.profileImage === null)
-        setPreviewUrl(saved.profileImage ?? null)
-    } catch {}
-  }, [])
-
   const handleClickUpload = () => {
     fileRef.current?.click()
   }
 
-  const handleChangeFile: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+  const handleChangeFile: ChangeEventHandler<HTMLInputElement> = (e) => {
     const file = e.target.files?.[0]
     if (!file) return
 
@@ -227,25 +243,26 @@ export function MyInformationFix() {
 
           {(() => {
             const hasTyped = nickname.length > 0
-
             const isLengthOk = nickname.length >= 2 && nickname.length <= 12
             const isCharOk = /^[A-Za-z0-9가-힣]+$/.test(nickname)
             const isBannedOk = true // TODO: 금지어 체크 API 연결 전까지는 true
 
-            const ruleTextColor = (ok: boolean) => {
+            const nicknameRuleTextColor = (ok: boolean) => {
               if (!hasTyped) return 'text-brand-gray-300'
               return ok ? 'text-brand-green' : 'text-brand-main'
             }
 
             return (
               <div className="mt-3 text-xs leading-5">
-                <p className={ruleTextColor(isLengthOk)}>
+                <p className={nicknameRuleTextColor(isLengthOk)}>
                   ✓ 최소 2글자 최대 12글자
                 </p>
-                <p className={ruleTextColor(isCharOk)}>
+                <p className={nicknameRuleTextColor(isCharOk)}>
                   ✓ 한글, 영문, 숫자만 사용 가능 (특수문자, 공백 불가)
                 </p>
-                <p className={ruleTextColor(isBannedOk)}>✓ 금지어 포함 불가</p>
+                <p className={nicknameRuleTextColor(isBannedOk)}>
+                  ✓ 금지어 포함 불가
+                </p>
               </div>
             )
           })()}
@@ -320,8 +337,10 @@ export function MyInformationFix() {
                 />
 
                 <div className="mt-3 text-sm leading-6">
-                  <p className={cn(ruleTextColor(isMin8))}>✓ 최소 8글자</p>
-                  <p className={cn(ruleTextColor(isComboOk))}>
+                  <p className={cn(passwordRuleTextColor(isMin8))}>
+                    ✓ 최소 8글자
+                  </p>
+                  <p className={cn(passwordRuleTextColor(isComboOk))}>
                     ✓ 영문, 숫자, 특수문자 조합
                   </p>
                 </div>

--- a/src/features/mypage-my-information-fix/ui/MyInformationFix.tsx
+++ b/src/features/mypage-my-information-fix/ui/MyInformationFix.tsx
@@ -1,0 +1,285 @@
+'use client'
+
+import * as React from 'react'
+import Image from 'next/image'
+
+import { Input } from '@/shared/ui/input'
+import { Button } from '@/shared/ui/Button'
+import { cn } from '@/shared/lib/cn'
+
+type UserRole = 'user' | 'admin' | 'instructor'
+
+export function MyInformationFix() {
+  const fileRef = React.useRef<HTMLInputElement>(null)
+  const [previewUrl, setPreviewUrl] = React.useState<string | null>(null)
+
+  const userRole: UserRole = 'user' // TODO: 실제 유저 role로 교체
+  const [nickname, setNickname] = React.useState('fortes42')
+  const nameValue = '박진우'
+  const joinedAtValue = '2026.01.08'
+  const emailValue = 'forteslv42@gmail.com'
+  const phoneValue = '01012345678'
+  const [marketingAgree, setMarketingAgree] = React.useState(true)
+
+  // TODO: globals.css의 실제 클래스명에 맞게 여기만 바꿔주면 됨
+  const profileBorderClass = {
+    user: 'border-brand-green',
+    admin: 'border-brand-purple',
+    instructor: 'border-brand-blue',
+  }[userRole]
+
+  const handleClickUpload = () => {
+    fileRef.current?.click()
+  }
+
+  const handleChangeFile: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    const url = URL.createObjectURL(file)
+    setPreviewUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev)
+      return url
+    })
+  }
+
+  const handleClickResetImage = () => {
+    setPreviewUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev)
+      return null
+    })
+    if (fileRef.current) fileRef.current.value = ''
+  }
+
+  React.useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl)
+    }
+  }, [previewUrl])
+
+  return (
+    <main className="bg-brand-white w-full">
+      <section className="mx-auto w-full max-w-6xl px-6 py-10">
+        <h1 className="text-brand-black text-3xl font-bold">내 정보 수정</h1>
+        <div className="bg-brand-gray-200 mt-6 h-px w-full" />
+
+        <div className="mt-10 grid grid-cols-1 gap-10 lg:grid-cols-2">
+          <div className="flex items-start gap-10">
+            <div className="flex flex-col items-center">
+              <div
+                className={cn(
+                  'bg-brand-gray-100 relative h-36 w-36 overflow-hidden rounded-full border-4',
+                  profileBorderClass
+                )}
+              >
+                <Image
+                  src={previewUrl ?? '/images/profiles/default-1.webp'}
+                  alt="프로필 이미지"
+                  fill
+                  sizes="144px"
+                  className="object-cover"
+                  priority
+                />
+              </div>
+            </div>
+
+            <div className="text-brand-gray-300 pt-3 text-sm leading-7">
+              <p>• 최대 5 MB까지 업로드 가능합니다.</p>
+              <p>• 확장자는 JPG, PNG 사용 가능합니다.</p>
+
+              <div className="mt-4 flex items-center gap-3">
+                <input
+                  ref={fileRef}
+                  type="file"
+                  accept="image/png, image/jpeg"
+                  className="hidden"
+                  onChange={handleChangeFile}
+                />
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleClickUpload}
+                >
+                  업로드
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleClickResetImage}
+                >
+                  기본 이미지
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <div className="w-full max-w-lg">
+            <div className="grid grid-cols-1 gap-6">
+              <div>
+                <p className="text-brand-gray-400 mb-2 text-sm">이름</p>
+                <Input value={nameValue} disabled />
+              </div>
+
+              <div>
+                <p className="text-brand-gray-400 mb-2 text-sm">최초 가입일</p>
+                <Input value={joinedAtValue} disabled />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-10">
+          <div className="flex items-end gap-4">
+            <div className="flex-1">
+              <p className="text-brand-gray-400 mb-2 text-sm">닉네임</p>
+              <Input
+                value={nickname}
+                onChange={(e) => setNickname(e.target.value)}
+                placeholder="닉네임을 입력해 주세요"
+              />
+            </div>
+
+            <Button
+              type="button"
+              variant="secondary"
+              size="md"
+              className="min-w-32"
+              onClick={() => {
+                // TODO: 닉네임 중복 확인 API 연결
+                alert('중복 확인 (UI 더미)')
+              }}
+            >
+              중복 확인
+            </Button>
+          </div>
+
+          <div className="text-brand-gray-300 mt-3 text-xs leading-5">
+            <p>✓ 최소 2글자 최대 12글자</p>
+            <p>✓ 한글,영문, 숫자만 사용 가능(특수문자, 공백 불가)</p>
+            <p>✓ 금지어 포함 불가</p>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <div className="flex items-end gap-4">
+            <div className="flex-1">
+              <p className="text-brand-gray-400 mb-2 text-sm">이메일</p>
+              <Input value={emailValue} disabled />
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="md"
+              className="min-w-32"
+              disabled
+            >
+              인증 완료
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <div className="flex items-end gap-4">
+            <div className="flex-1">
+              <p className="text-brand-gray-400 mb-2 text-sm">전화번호</p>
+              <Input value={phoneValue} disabled />
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="md"
+              className="min-w-32"
+              disabled
+            >
+              인증 완료
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <div className="flex items-end gap-4">
+            <div className="flex-1">
+              <p className="text-brand-gray-400 mb-2 text-sm">기존 비밀번호</p>
+              <Input type="password" value="***************" readOnly />
+            </div>
+
+            <Button
+              type="button"
+              variant="secondary"
+              size="md"
+              className="min-w-32"
+              onClick={() => {
+                // TODO: 비밀번호 변경 플로우 연결(모달/페이지 등)
+                alert('비밀번호 변경 (UI 더미)')
+              }}
+            >
+              비밀번호 변경
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-12">
+          <h2 className="text-brand-black text-base font-bold">선택 정보</h2>
+          <div className="bg-brand-gray-200 mt-4 h-px w-full" />
+
+          <div className="mt-6 flex items-start gap-4">
+            <label className="flex cursor-pointer items-start gap-3 select-none">
+              <div className="text-sm leading-6">
+                <p className="text-brand-black font-medium">마케팅 수신 동의</p>
+              </div>
+              <input
+                type="checkbox"
+                checked={marketingAgree}
+                onChange={(e) => setMarketingAgree(e.target.checked)}
+                className={cn(
+                  'border-brand-gray-300 mt-1 ml-10 h-4 w-4 rounded border',
+                  'accent-brand-main'
+                )}
+              />
+              <div className="text-brand-gray-400 text-sm leading-6">
+                <p>
+                  스터디고 스페셜한 소식을 이메일, 문자, 카카오 알림톡 등 다양한
+                  채널로 받아봅니다.
+                </p>
+                <p className="text-brand-gray-300 mt-1 text-xs leading-5">
+                  ※ 이용약관의 변경이나 관계법령에 따라 회원님께 안내되어야 할
+                  중요 고지사항은
+                  <br />
+                  마케팅 수신 동의와 상관없이 안내될 수 있습니다.
+                </p>
+              </div>
+            </label>
+          </div>
+        </div>
+
+        <div className="mt-10 flex items-center justify-between">
+          <button
+            type="button"
+            className="text-brand-gray-300 text-sm underline underline-offset-4"
+            onClick={() => {
+              // TODO: 회원탈퇴 페이지/모달 연결
+              alert('회원탈퇴 (UI 더미)')
+            }}
+          >
+            회원탈퇴
+          </button>
+
+          <Button
+            type="button"
+            variant="primary"
+            size="reg"
+            className="min-w-44"
+            onClick={() => {
+              // TODO: 저장 API 연결
+              alert('내 정보 저장하기 (UI 더미)')
+            }}
+          >
+            내 정보 저장하기
+          </Button>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/features/mypage-my-information-fix/ui/MyInformationFix.tsx
+++ b/src/features/mypage-my-information-fix/ui/MyInformationFix.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import Image from 'next/image'
+import { useRouter } from 'next/navigation'
 
 import { Input } from '@/shared/ui/input'
 import { Button } from '@/shared/ui/Button'
@@ -9,7 +10,17 @@ import { cn } from '@/shared/lib/cn'
 
 type UserRole = 'user' | 'admin' | 'instructor'
 
+type MyInfoDraft = {
+  nickname: string
+  marketingAgree: boolean
+  profileImage?: string | null // dataURL or null
+}
+
+const MYINFO_STORAGE_KEY = 'studigo_myinfo_draft'
+
 export function MyInformationFix() {
+  const router = useRouter()
+
   const fileRef = React.useRef<HTMLInputElement>(null)
   const [previewUrl, setPreviewUrl] = React.useState<string | null>(null)
 
@@ -21,12 +32,50 @@ export function MyInformationFix() {
   const phoneValue = '01012345678'
   const [marketingAgree, setMarketingAgree] = React.useState(true)
 
-  // TODO: globals.css의 실제 클래스명에 맞게 여기만 바꿔주면 됨
+  const [isPasswordEditing, setIsPasswordEditing] = React.useState(false)
+
+  const [currentPassword] = React.useState('***************')
+  const [newPassword, setNewPassword] = React.useState('')
+  const [newPasswordConfirm, setNewPasswordConfirm] = React.useState('')
+
+  const hasTypedNewPw = isPasswordEditing && newPassword.length > 0
+
+  const isMin8 = newPassword.length >= 8
+  const hasLetter = /[A-Za-z]/.test(newPassword)
+  const hasNumber = /\d/.test(newPassword)
+  const hasSpecial = /[^A-Za-z0-9]/.test(newPassword)
+  const isComboOk = hasLetter && hasNumber && hasSpecial
+
+  const ruleTextColor = (ok: boolean) => {
+    if (!hasTypedNewPw) return 'text-brand-gray-300'
+    return ok ? 'text-brand-green' : 'text-brand-main'
+  }
+
+  const isPasswordMismatch =
+    isPasswordEditing &&
+    newPasswordConfirm.length > 0 &&
+    newPassword !== newPasswordConfirm
+
   const profileBorderClass = {
     user: 'border-brand-green',
     admin: 'border-brand-purple',
     instructor: 'border-brand-blue',
   }[userRole]
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      const raw = localStorage.getItem(MYINFO_STORAGE_KEY)
+      if (!raw) return
+      const saved = JSON.parse(raw) as MyInfoDraft
+
+      if (typeof saved.nickname === 'string') setNickname(saved.nickname)
+      if (typeof saved.marketingAgree === 'boolean')
+        setMarketingAgree(saved.marketingAgree)
+      if (typeof saved.profileImage === 'string' || saved.profileImage === null)
+        setPreviewUrl(saved.profileImage ?? null)
+    } catch {}
+  }, [])
 
   const handleClickUpload = () => {
     fileRef.current?.click()
@@ -36,26 +85,50 @@ export function MyInformationFix() {
     const file = e.target.files?.[0]
     if (!file) return
 
-    const url = URL.createObjectURL(file)
-    setPreviewUrl((prev) => {
-      if (prev) URL.revokeObjectURL(prev)
-      return url
-    })
+    if (file.size > 5 * 1024 * 1024) {
+      alert('최대 5MB까지 업로드 가능합니다.')
+      if (fileRef.current) fileRef.current.value = ''
+      return
+    }
+
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : null
+      setPreviewUrl(result)
+    }
+    reader.readAsDataURL(file)
   }
 
   const handleClickResetImage = () => {
-    setPreviewUrl((prev) => {
-      if (prev) URL.revokeObjectURL(prev)
-      return null
-    })
+    setPreviewUrl(null)
     if (fileRef.current) fileRef.current.value = ''
   }
 
-  React.useEffect(() => {
-    return () => {
-      if (previewUrl) URL.revokeObjectURL(previewUrl)
+  const togglePasswordEdit = () => {
+    setIsPasswordEditing((prev) => {
+      const next = !prev
+      if (!next) {
+        setNewPassword('')
+        setNewPasswordConfirm('')
+      }
+      return next
+    })
+  }
+
+  const handleSave = () => {
+    const payload: MyInfoDraft = {
+      nickname,
+      marketingAgree,
+      profileImage: previewUrl ?? null,
     }
-  }, [previewUrl])
+
+    try {
+      localStorage.setItem(MYINFO_STORAGE_KEY, JSON.stringify(payload))
+    } catch {}
+
+    router.push('/mypage')
+    router.refresh()
+  }
 
   return (
     <main className="bg-brand-white w-full">
@@ -146,20 +219,36 @@ export function MyInformationFix() {
               variant="secondary"
               size="md"
               className="min-w-32"
-              onClick={() => {
-                // TODO: 닉네임 중복 확인 API 연결
-                alert('중복 확인 (UI 더미)')
-              }}
+              onClick={() => alert('중복 확인 (UI 더미)')}
             >
               중복 확인
             </Button>
           </div>
 
-          <div className="text-brand-gray-300 mt-3 text-xs leading-5">
-            <p>✓ 최소 2글자 최대 12글자</p>
-            <p>✓ 한글,영문, 숫자만 사용 가능(특수문자, 공백 불가)</p>
-            <p>✓ 금지어 포함 불가</p>
-          </div>
+          {(() => {
+            const hasTyped = nickname.length > 0
+
+            const isLengthOk = nickname.length >= 2 && nickname.length <= 12
+            const isCharOk = /^[A-Za-z0-9가-힣]+$/.test(nickname)
+            const isBannedOk = true // TODO: 금지어 체크 API 연결 전까지는 true
+
+            const ruleTextColor = (ok: boolean) => {
+              if (!hasTyped) return 'text-brand-gray-300'
+              return ok ? 'text-brand-green' : 'text-brand-main'
+            }
+
+            return (
+              <div className="mt-3 text-xs leading-5">
+                <p className={ruleTextColor(isLengthOk)}>
+                  ✓ 최소 2글자 최대 12글자
+                </p>
+                <p className={ruleTextColor(isCharOk)}>
+                  ✓ 한글, 영문, 숫자만 사용 가능 (특수문자, 공백 불가)
+                </p>
+                <p className={ruleTextColor(isBannedOk)}>✓ 금지어 포함 불가</p>
+              </div>
+            )
+          })()}
         </div>
 
         <div className="mt-8">
@@ -202,7 +291,7 @@ export function MyInformationFix() {
           <div className="flex items-end gap-4">
             <div className="flex-1">
               <p className="text-brand-gray-400 mb-2 text-sm">기존 비밀번호</p>
-              <Input type="password" value="***************" readOnly />
+              <Input type="password" value={currentPassword} readOnly />
             </div>
 
             <Button
@@ -210,14 +299,54 @@ export function MyInformationFix() {
               variant="secondary"
               size="md"
               className="min-w-32"
-              onClick={() => {
-                // TODO: 비밀번호 변경 플로우 연결(모달/페이지 등)
-                alert('비밀번호 변경 (UI 더미)')
-              }}
+              onClick={togglePasswordEdit}
             >
-              비밀번호 변경
+              {isPasswordEditing ? '변경 취소' : '비밀번호 변경'}
             </Button>
           </div>
+
+          {isPasswordEditing && (
+            <div className="mt-6 grid grid-cols-1 gap-6">
+              <div>
+                <p className="text-brand-gray-400 mb-2 text-sm">
+                  새로운 비밀번호
+                </p>
+
+                <Input
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  placeholder="새로운 비밀번호를 입력해주세요."
+                />
+
+                <div className="mt-3 text-sm leading-6">
+                  <p className={cn(ruleTextColor(isMin8))}>✓ 최소 8글자</p>
+                  <p className={cn(ruleTextColor(isComboOk))}>
+                    ✓ 영문, 숫자, 특수문자 조합
+                  </p>
+                </div>
+              </div>
+
+              <div>
+                <p className="text-brand-gray-400 mb-2 text-sm">
+                  새로운 비밀번호 확인
+                </p>
+
+                <Input
+                  type="password"
+                  value={newPasswordConfirm}
+                  onChange={(e) => setNewPasswordConfirm(e.target.value)}
+                  placeholder="비밀번호를 한 번 더 입력해주세요."
+                />
+
+                {isPasswordMismatch && (
+                  <p className="text-brand-main mt-2 text-sm">
+                    비밀번호가 일치하지 않습니다.
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="mt-12">
@@ -229,15 +358,17 @@ export function MyInformationFix() {
               <div className="text-sm leading-6">
                 <p className="text-brand-black font-medium">마케팅 수신 동의</p>
               </div>
+
               <input
                 type="checkbox"
                 checked={marketingAgree}
                 onChange={(e) => setMarketingAgree(e.target.checked)}
                 className={cn(
-                  'border-brand-gray-300 mt-1 ml-10 h-4 w-4 rounded border',
+                  'border-brand-gray-300 mt-0.5 ml-2 h-4 w-4 rounded border',
                   'accent-brand-main'
                 )}
               />
+
               <div className="text-brand-gray-400 text-sm leading-6">
                 <p>
                   스터디고 스페셜한 소식을 이메일, 문자, 카카오 알림톡 등 다양한
@@ -258,10 +389,7 @@ export function MyInformationFix() {
           <button
             type="button"
             className="text-brand-gray-300 text-sm underline underline-offset-4"
-            onClick={() => {
-              // TODO: 회원탈퇴 페이지/모달 연결
-              alert('회원탈퇴 (UI 더미)')
-            }}
+            onClick={() => alert('회원탈퇴 (UI 더미)')}
           >
             회원탈퇴
           </button>
@@ -271,10 +399,7 @@ export function MyInformationFix() {
             variant="primary"
             size="reg"
             className="min-w-44"
-            onClick={() => {
-              // TODO: 저장 API 연결
-              alert('내 정보 저장하기 (UI 더미)')
-            }}
+            onClick={handleSave}
           >
             내 정보 저장하기
           </Button>

--- a/src/features/mypage/ui/MyPage.tsx
+++ b/src/features/mypage/ui/MyPage.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ComponentType } from 'react'
 import PostFilter from '@/features/mypage/ui/PostFilter'
 import MyPost from '@/features/mypage/ui/MyPost'
 import MenuIcon from '@/features/mypage/assets/menu-icon.svg'
@@ -11,6 +11,61 @@ import { MY_TIMELINE } from '@/shared/api/mocks/data/mypage-data'
 
 type TabType = 'post' | 'comment' | 'like'
 
+type MyInfoDraft = {
+  nickname?: string
+  marketingAgree?: boolean
+  profileImage?: string | null
+}
+
+type ProfileOverrideProps = {
+  nickname?: string
+  profileImage?: string | null
+  marketingAgree?: boolean
+}
+
+const MYINFO_STORAGE_KEY = 'studigo_myinfo_draft'
+
+function getMyInfoDraft(): ProfileOverrideProps {
+  if (typeof window === 'undefined') {
+    return {
+      nickname: undefined,
+      marketingAgree: undefined,
+      profileImage: undefined,
+    }
+  }
+
+  try {
+    const raw = localStorage.getItem(MYINFO_STORAGE_KEY)
+    if (!raw) {
+      return {
+        nickname: undefined,
+        marketingAgree: undefined,
+        profileImage: undefined,
+      }
+    }
+
+    const saved = JSON.parse(raw) as MyInfoDraft
+
+    return {
+      nickname: typeof saved.nickname === 'string' ? saved.nickname : undefined,
+      marketingAgree:
+        typeof saved.marketingAgree === 'boolean'
+          ? saved.marketingAgree
+          : undefined,
+      profileImage:
+        typeof saved.profileImage === 'string' || saved.profileImage === null
+          ? saved.profileImage
+          : undefined,
+    }
+  } catch {
+    return {
+      nickname: undefined,
+      marketingAgree: undefined,
+      profileImage: undefined,
+    }
+  }
+}
+
 export default function MyPage() {
   const [tab, setTab] = useState<TabType>('post')
   const [page, setPage] = useState(1)
@@ -19,12 +74,23 @@ export default function MyPage() {
 
   const timeline = useMemo<TimelineItem[]>(() => MY_TIMELINE, [])
 
+  const [profileOverride] = useState<ProfileOverrideProps>(() =>
+    getMyInfoDraft()
+  )
+
+  const ProfileWithOverride =
+    Profile as unknown as ComponentType<ProfileOverrideProps>
+
   return (
     <div className="bg-brand-white min-h-screen">
       <section className="pt-10">
         <div className="relative mx-auto flex max-w-6xl flex-col items-center px-5">
           <div className="flex w-full flex-col items-center">
-            <Profile />
+            <ProfileWithOverride
+              nickname={profileOverride.nickname}
+              profileImage={profileOverride.profileImage}
+              marketingAgree={profileOverride.marketingAgree}
+            />
 
             <div className="border-brand-gray-200 w-full pb-10">
               <div className="mx-auto max-w-6xl px-5">
@@ -59,7 +125,7 @@ export default function MyPage() {
         <div className="mt-2">
           <MyPost />
         </div>
-        {/*TODO: 페이지 네이션 고치기*/}
+
         <div className="border-brand-gray-200 border-b" />
         <div className="my-14 flex justify-center">
           <Pagination page={page} totalPages={10} onChangePage={setPage} />

--- a/src/features/mypage/ui/Profile.tsx
+++ b/src/features/mypage/ui/Profile.tsx
@@ -1,7 +1,6 @@
 import Image from 'next/image'
 import { Button } from '@/shared/ui/Button'
-
-// Removed isMdDown prop and related logic
+import { useRouter } from 'next/navigation'
 
 function PinProfile() {
   return (
@@ -75,13 +74,16 @@ function Balloon({
 }
 
 export default function Profile() {
+  const router = useRouter()
   return (
     <div className="mb-10 flex w-full flex-row items-center justify-center gap-2 max-lg:gap-5 sm:gap-4 md:gap-8">
       <div className="flex min-w-0 flex-1 justify-end px-2 max-lg:px-5 sm:px-4 md:px-8">
         <div className="flex items-center gap-6 lg:gap-12">
           <Button
+            type="button"
             variant="secondary"
             size="md"
+            onClick={() => router.push('/mypage/my-information-fix')}
             className="w-28 px-3 py-1.5 text-sm lg:w-40 lg:px-4 lg:py-2 lg:text-base"
           >
             <span className="block">내 정보 수정</span>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #97 

## 📝작업 내용

> 마이페이지 내 정보 수정 화면 UI 구현
> 프로필 이미지 업로드 및 기본 이미지 변경 UI 추가
> 사용자 역할에 따른 프로필 테두리 색상 분기
> 닉네임 입력 및 조건 안내 문구 UX 개선
> 비밀번호 변경 UI 추가 및 조건 충족 여부 시각화
> 비밀번호 확인 불일치 안내 처리
> 내 정보 저장 시 마이페이지로 이동하는 흐름 구현

## 🖼️스크린샷

> 
https://github.com/user-attachments/assets/6d6150b5-ebe7-426a-bae0-d144af479889

https://github.com/user-attachments/assets/ac25bb92-26d5-4d09-9b4c-e64c2e71eaaf

## 💬리뷰 요구사항 (선택)



## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
