### PR TITLE
[Feature] 게시글 상세페이지 세부 UI - 2

### DIFF
--- a/src/features/community-comment-manage/ui/CommentActionMenu.tsx
+++ b/src/features/community-comment-manage/ui/CommentActionMenu.tsx
@@ -5,6 +5,7 @@ import { DropdownMenu } from '@/shared/ui/DropdownMenu'
 import ActionDropdown from '@/shared/ui/ActionDropdown'
 import { Share, Trash2 } from 'lucide-react'
 import { ConfirmModal } from '@/shared/ui/ConfirmModal'
+import { copyToClipboard } from '@/shared/lib/copyToClipboard'
 // import { revalidatePath } from 'next/cache'
 // import { deleteCommentAction } from '@/features/community-comment-manage/api/deleteCommentAction'
 // import { useRouter } from 'next/navigation'
@@ -12,17 +13,22 @@ import { ConfirmModal } from '@/shared/ui/ConfirmModal'
 interface CommentActionMenuProps {
   postId: number
   commentId: number
+  currentPage?: number
 }
 
 export default function CommentActionMenu({
   postId,
   commentId,
+  currentPage,
 }: CommentActionMenuProps) {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
 
   const handleShare = () => {
-    // TODO: 공유 기능 구현
-    console.log('공유하기', postId)
+    const pageParam =
+      currentPage && currentPage > 1 ? `?page=${currentPage}` : ''
+    const hash = `#comment-${commentId}`
+    const url = `${window.location.origin}/community/${postId}${pageParam}${hash}`
+    copyToClipboard(url)
   }
 
   const handleDelete = async () => {

--- a/src/features/community-post-manage/ui/PostActionMenu.tsx
+++ b/src/features/community-post-manage/ui/PostActionMenu.tsx
@@ -6,6 +6,7 @@ import ActionDropdown from '@/shared/ui/ActionDropdown'
 import { Pencil, Share, Trash2 } from 'lucide-react'
 import { ConfirmModal } from '@/shared/ui/ConfirmModal'
 import { useRouter } from 'next/navigation'
+import { copyToClipboard } from '@/shared/lib/copyToClipboard'
 // import { revalidatePath } from 'next/cache'
 // import { deletePostAction } from '@/features/community-post-manage/api/deletePostAction'
 
@@ -19,8 +20,8 @@ export default function PostActionMenu({ postId }: PostActionMenuProps) {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
 
   const handleShare = () => {
-    // TODO: 공유 기능 구현
-    console.log('공유하기')
+    const url = `${window.location.origin}/community/${postId}`
+    copyToClipboard(url)
   }
 
   const handleDelete = async () => {

--- a/src/features/community-report/model/schema.ts
+++ b/src/features/community-report/model/schema.ts
@@ -5,10 +5,10 @@ import { REPORT_REASON_MAX_LENGTH } from '@/entities/post/model/constants'
 export const ReportFormSchema = z.object({
   reason: z
     .string()
-    .min(1, '신고 이유를 입력해주세요.')
+    .min(1, '신고 사유를 입력해주세요.')
     .max(
       REPORT_REASON_MAX_LENGTH,
-      `신고 이유는 ${REPORT_REASON_MAX_LENGTH}자 이내로 입력해주세요.`
+      `신고 사유는 ${REPORT_REASON_MAX_LENGTH}자 이내로 입력해주세요.`
     ),
 })
 

--- a/src/features/community-report/ui/CommentReportButton.tsx
+++ b/src/features/community-report/ui/CommentReportButton.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { Siren } from 'lucide-react'
 import { Button } from '@/shared/ui/Button'
 import { cn } from '@/shared/lib/cn'
-import { ConfirmModal } from '@/shared/ui/ConfirmModal'
+import { ReportModal } from '@/features/community-report/ui/ReportModal'
 
 interface CommentReportButtonProps {
   onClick?: () => void
@@ -17,8 +17,8 @@ export default function CommentReportButton({
 }: CommentReportButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false)
 
-  const handleConfirm = () => {
-    console.log('신고')
+  const handleConfirm = (reason: string) => {
+    console.log('신고 사유:', reason)
     setIsModalOpen(false)
     onClick?.()
   }
@@ -38,14 +38,13 @@ export default function CommentReportButton({
         <span>신고</span>
       </Button>
 
-      <ConfirmModal
+      <ReportModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         onConfirm={handleConfirm}
-        title="알림"
-      >
-        댓글을 <span className="text-brand-third">신고</span> 하시겠습니까?
-      </ConfirmModal>
+        title="댓글 신고"
+        targetName="댓글"
+      />
     </>
   )
 }

--- a/src/features/community-report/ui/PostReportButton.tsx
+++ b/src/features/community-report/ui/PostReportButton.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { Siren } from 'lucide-react'
 import { Button } from '@/shared/ui/Button'
 import { cn } from '@/shared/lib/cn'
-import { ConfirmModal } from '@/shared/ui/ConfirmModal'
+import { ReportModal } from '@/features/community-report/ui/ReportModal'
 
 interface PostReportButtonProps {
   onClick?: () => void
@@ -17,8 +17,8 @@ export default function PostReportButton({
 }: PostReportButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false)
 
-  const handleConfirm = () => {
-    console.log('신고')
+  const handleConfirm = (reason: string) => {
+    console.log('신고 사유:', reason)
     setIsModalOpen(false)
     onClick?.()
   }
@@ -38,14 +38,13 @@ export default function PostReportButton({
         <span>신고</span>
       </Button>
 
-      <ConfirmModal
+      <ReportModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         onConfirm={handleConfirm}
-        title="알림"
-      >
-        게시글을 <span className="text-brand-third">신고</span> 하시겠습니까?
-      </ConfirmModal>
+        title="게시글 신고"
+        targetName="게시글"
+      />
     </>
   )
 }

--- a/src/features/community-report/ui/ReportModal.tsx
+++ b/src/features/community-report/ui/ReportModal.tsx
@@ -75,10 +75,13 @@ export function ReportModal({
         <Textarea
           {...register('reason')}
           placeholder="신고 사유를 입력해주세요. (최대 100자)"
-          className={cn('h-28 resize-none p-3', !errors.reason && 'mb-5')}
+          className={cn(
+            'h-28 resize-none p-3 focus-visible:ring-0',
+            !errors.reason ? 'mb-5' : 'border-brand-error'
+          )}
         />
         {errors.reason && (
-          <span className="text-xs font-medium text-red-500">
+          <span className="text-brand-error text-xs font-medium">
             {errors.reason.message}
           </span>
         )}

--- a/src/features/community-report/ui/ReportModal.tsx
+++ b/src/features/community-report/ui/ReportModal.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import React, { useEffect } from 'react'
+import { Modal, ModalClose, ModalDescription } from '@/shared/ui/Modal'
+import { Button, ButtonVariants } from '@/shared/ui/Button'
+import { cn } from '@/shared/lib/cn'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  ReportForm,
+  ReportFormSchema,
+} from '@/features/community-report/model/schema'
+import { Textarea } from '@/shared/ui/Textarea'
+
+interface ReportModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: (reason: string) => void
+  title: string
+  targetName: string
+  isPending?: boolean
+}
+
+export function ReportModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  targetName,
+  isPending,
+}: ReportModalProps) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isValid },
+  } = useForm<ReportForm>({
+    resolver: zodResolver(ReportFormSchema),
+    mode: 'onChange',
+    defaultValues: {
+      reason: '',
+    },
+  })
+
+  useEffect(() => {
+    if (isOpen) {
+      reset()
+    }
+  }, [isOpen, reset])
+
+  const onFormSubmit = (data: ReportForm) => {
+    onConfirm(data.reason)
+  }
+
+  return (
+    <Modal
+      title={title}
+      isOpen={isOpen}
+      onClose={onClose}
+      size="sm"
+      contentClassName="flex flex-col items-center"
+    >
+      <div className="text-center text-base font-semibold break-keep">
+        {targetName}을 <span className="text-brand-third">신고</span>{' '}
+        하시겠습니까?
+      </div>
+
+      <ModalDescription className="sr-only">신고 사유 입력</ModalDescription>
+
+      <form
+        id="report-form"
+        onSubmit={handleSubmit(onFormSubmit)}
+        className="my-4 flex w-full flex-col gap-1"
+      >
+        <Textarea
+          {...register('reason')}
+          placeholder="신고 사유를 입력해주세요. (최대 100자)"
+          className="h-32 resize-none"
+        />
+        {errors.reason && (
+          <span className="text-xs font-medium text-red-500">
+            {errors.reason.message}
+          </span>
+        )}
+      </form>
+
+      <div className="flex gap-2">
+        <ModalClose
+          className={cn(
+            ButtonVariants({ variant: 'outline', size: 'md' }),
+            'px-10'
+          )}
+          disabled={isPending}
+          onClick={onClose}
+        >
+          취소
+        </ModalClose>
+        <Button
+          type="submit"
+          form="report-form"
+          size="md"
+          className="bg-brand-main px-10"
+          disabled={isPending || !isValid}
+        >
+          신고
+        </Button>
+      </div>
+    </Modal>
+  )
+}

--- a/src/features/community-report/ui/ReportModal.tsx
+++ b/src/features/community-report/ui/ReportModal.tsx
@@ -75,7 +75,7 @@ export function ReportModal({
         <Textarea
           {...register('reason')}
           placeholder="신고 사유를 입력해주세요. (최대 100자)"
-          className="h-32 resize-none"
+          className={cn('h-28 resize-none p-3', !errors.reason && 'mb-5')}
         />
         {errors.reason && (
           <span className="text-xs font-medium text-red-500">

--- a/src/shared/lib/copyToClipboard.ts
+++ b/src/shared/lib/copyToClipboard.ts
@@ -1,0 +1,36 @@
+import { toast } from 'sonner'
+
+interface CopyToClipboardOptions {
+  successMessage?: string
+  errorMessage?: string
+}
+
+/**
+ * 텍스트를 클립보드에 복사하고 토스트 알림을 표시합니다.
+ * @note 이 함수는 브라우저 환경(Client Side)에서만 동작합니다. (navigator.clipboard 사용)
+ */
+export async function copyToClipboard(
+  text: string,
+  options: CopyToClipboardOptions = {}
+): Promise<boolean> {
+  const {
+    successMessage = '클립보드에 복사되었습니다.',
+    errorMessage = '클립보드 복사에 실패했습니다.',
+  } = options
+
+  if (typeof navigator === 'undefined' || !navigator.clipboard) {
+    toast.error('이 브라우저에서는 클립보드 기능을 사용할 수 없습니다.')
+    console.warn('Clipboard API not supported')
+    return false
+  }
+
+  try {
+    await navigator.clipboard.writeText(text)
+    if (successMessage) toast.success(successMessage)
+    return true
+  } catch (error) {
+    console.warn('클립보드 복사 실패', error)
+    if (errorMessage) toast.error(errorMessage)
+    return false
+  }
+}

--- a/src/shared/ui/text-editor/MenuBar.tsx
+++ b/src/shared/ui/text-editor/MenuBar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useTiptap, useTiptapState } from '@tiptap/react'
-import { menuBarStateSelector } from '@/shared/ui/text-editor/config'
+import { menuBarStateSelector } from '@/shared/ui/text-editor/utils'
 import HyperLink from '@/shared/ui/text-editor/HyperLink'
 import ImageLink from '@/shared/ui/text-editor/ImageLink'
 import YoutubeLink from '@/shared/ui/text-editor/YoutubeLink'

--- a/src/shared/ui/text-editor/TextEditor.tsx
+++ b/src/shared/ui/text-editor/TextEditor.tsx
@@ -1,23 +1,20 @@
 import { ComponentProps, useEffect } from 'react'
 
 import { Tiptap, useEditor } from '@tiptap/react'
-import StarterKit from '@tiptap/starter-kit'
-import Highlight from '@tiptap/extension-highlight'
-import TextAlign from '@tiptap/extension-text-align'
+
 import Placeholder from '@tiptap/extension-placeholder'
 import { cn } from '@/shared/lib/cn'
 import MenuBar from '@/shared/ui/text-editor/MenuBar'
 import WordCount from '@/shared/ui/text-editor/WordCount'
-import { linkConfigure } from '@/shared/ui/text-editor/HyperLink'
-import { youtubeConfigure } from '@/shared/ui/text-editor/YoutubeLink'
-import { imageConfigure } from '@/shared/ui/text-editor/ImageLink'
+import { baseExtensions } from '@/shared/ui/text-editor/extensions'
 
-import { editorContentStyles } from '@/shared/ui/text-editor/config'
+import { editorContentStyles } from '@/shared/ui/text-editor/styles'
 
 interface TextEditorProps extends Omit<ComponentProps<'div'>, 'onChange'> {
   value?: string
   onChange?: (value: string) => void
   onBlur?: () => void
+  className?: string
 }
 
 export default function TextEditor({
@@ -29,20 +26,7 @@ export default function TextEditor({
 }: TextEditorProps) {
   const editor = useEditor({
     extensions: [
-      StarterKit.configure({
-        link: false,
-      }),
-      Highlight.configure({
-        HTMLAttributes: {
-          class: 'bg-brand-side py-[3px]',
-        },
-      }),
-      TextAlign.configure({
-        types: ['heading', 'paragraph'],
-      }),
-      linkConfigure,
-      imageConfigure,
-      youtubeConfigure,
+      ...baseExtensions,
       Placeholder.configure({
         placeholder: '내용을 입력하세요...',
       }),
@@ -94,6 +78,7 @@ export default function TextEditor({
         {editor && (
           <>
             <MenuBar />
+            {/* Tiptap.Content 도 className 적용 가능 */}
             <Tiptap.Content className="" />
             <WordCount />
           </>

--- a/src/shared/ui/text-editor/TextViewer.tsx
+++ b/src/shared/ui/text-editor/TextViewer.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useEditor, Tiptap } from '@tiptap/react'
+import { baseExtensions } from '@/shared/ui/text-editor/extensions'
+import { editorContentStyles } from '@/shared/ui/text-editor/styles'
+import { tryParseJson } from '@/shared/ui/text-editor/utils'
+
+interface TextViewerProps {
+  content?: string
+  className?: string
+}
+
+export default function TextViewer({ content, className }: TextViewerProps) {
+  const editor = useEditor({
+    extensions: baseExtensions,
+    content: tryParseJson(content),
+    editable: false,
+    immediatelyRender: false,
+    editorProps: {
+      attributes: {
+        class: editorContentStyles(),
+      },
+    },
+  })
+
+  // 데이터가 변경될 때 에디터 내용 업데이트 (그럴일은 없지만)
+  useEffect(() => {
+    if (!editor || !content) return
+    const parsed = tryParseJson(content)
+    if (JSON.stringify(editor.getJSON()) !== JSON.stringify(parsed)) {
+      editor.commands.setContent(parsed)
+    }
+  }, [editor, content])
+
+  if (!editor) {
+    return null
+  }
+
+  return (
+    <Tiptap instance={editor}>
+      <Tiptap.Content className={className} />
+    </Tiptap>
+  )
+}

--- a/src/shared/ui/text-editor/extensions.ts
+++ b/src/shared/ui/text-editor/extensions.ts
@@ -1,0 +1,23 @@
+import StarterKit from '@tiptap/starter-kit'
+import Highlight from '@tiptap/extension-highlight'
+import TextAlign from '@tiptap/extension-text-align'
+import { linkConfigure } from '@/shared/ui/text-editor/HyperLink'
+import { youtubeConfigure } from '@/shared/ui/text-editor/YoutubeLink'
+import { imageConfigure } from '@/shared/ui/text-editor/ImageLink'
+
+export const baseExtensions = [
+  StarterKit.configure({
+    link: false,
+  }),
+  Highlight.configure({
+    HTMLAttributes: {
+      class: 'bg-brand-side py-[3px]',
+    },
+  }),
+  TextAlign.configure({
+    types: ['heading', 'paragraph'],
+  }),
+  linkConfigure,
+  imageConfigure,
+  youtubeConfigure,
+]

--- a/src/shared/ui/text-editor/styles.ts
+++ b/src/shared/ui/text-editor/styles.ts
@@ -1,0 +1,28 @@
+import { cva } from 'class-variance-authority'
+
+export const editorContentStyles = cva([
+  // 기본
+  'min-h-140 max-w-none px-4 py-8',
+  'prose dark:prose-invert',
+  'focus:outline-none',
+
+  // Placeholder
+  '[&_.is-editor-empty:first-child::before]:text-brand-gray-300',
+  '[&_.is-editor-empty:first-child::before]:content-[attr(data-placeholder)]',
+  '[&_.is-editor-empty:first-child::before]:float-left',
+  '[&_.is-editor-empty:first-child::before]:h-0',
+  '[&_.is-editor-empty:first-child::before]:pointer-events-none',
+
+  // Image Resize
+  '[&_[data-resize-wrapper]_img]:!my-0',
+  '[&_[data-resize-handle]]:w-4',
+  '[&_[data-resize-handle]]:h-4',
+  '[&_[data-resize-handle]]:bg-transparent',
+  '[&_[data-resize-handle]]:z-50',
+
+  // Cursors
+  '[&_[data-resize-handle="top-left"]]:cursor-nw-resize',
+  '[&_[data-resize-handle="top-right"]]:cursor-ne-resize',
+  '[&_[data-resize-handle="bottom-left"]]:cursor-sw-resize',
+  '[&_[data-resize-handle="bottom-right"]]:cursor-se-resize',
+])

--- a/src/shared/ui/text-editor/utils.ts
+++ b/src/shared/ui/text-editor/utils.ts
@@ -1,33 +1,19 @@
-import { cva } from 'class-variance-authority'
 import type { Editor } from '@tiptap/core'
 import type { EditorStateSnapshot } from '@tiptap/react'
 
-export const editorContentStyles = cva([
-  // 기본
-  'min-h-140 max-w-none px-4 py-8',
-  'prose dark:prose-invert',
-  'focus:outline-none',
-
-  // Placeholder
-  '[&_.is-editor-empty:first-child::before]:text-brand-gray-300',
-  '[&_.is-editor-empty:first-child::before]:content-[attr(data-placeholder)]',
-  '[&_.is-editor-empty:first-child::before]:float-left',
-  '[&_.is-editor-empty:first-child::before]:h-0',
-  '[&_.is-editor-empty:first-child::before]:pointer-events-none',
-
-  // Image Resize
-  '[&_[data-resize-wrapper]_img]:!my-0',
-  '[&_[data-resize-handle]]:w-4',
-  '[&_[data-resize-handle]]:h-4',
-  '[&_[data-resize-handle]]:bg-transparent',
-  '[&_[data-resize-handle]]:z-50',
-
-  // Cursors
-  '[&_[data-resize-handle="top-left"]]:cursor-nw-resize',
-  '[&_[data-resize-handle="top-right"]]:cursor-ne-resize',
-  '[&_[data-resize-handle="bottom-left"]]:cursor-sw-resize',
-  '[&_[data-resize-handle="bottom-right"]]:cursor-se-resize',
-])
+export function tryParseJson(content?: string) {
+  if (!content) return ''
+  try {
+    const parsed = JSON.parse(content)
+    if (typeof parsed === 'object' && parsed !== null) {
+      return parsed
+    }
+  } catch {
+    // JSON 파싱에 실패하면 일반 문자열(또는 HTML)로 간주하고 무시
+    // 그렇지만 직접 데이터를 넣지 않는 이상 그럴일은 절대 없음.
+  }
+  return content
+}
 
 export function menuBarStateSelector(ctx: EditorStateSnapshot<Editor>) {
   return {

--- a/src/widgets/community-comments/ui/CommunityComment.tsx
+++ b/src/widgets/community-comments/ui/CommunityComment.tsx
@@ -9,18 +9,20 @@ interface CommunityCommentProps {
   comment: Comment
   userId?: number
   postId: number
+  currentPage?: number
 }
 
 export default async function CommunityComment({
   comment,
   userId,
   postId,
+  currentPage,
 }: CommunityCommentProps) {
   const isAuthenticated = !!userId
   const isAuthor = userId === comment.author.id
 
   return (
-    <li className="flex justify-between py-2">
+    <li id={`comment-${comment.id}`} className="flex justify-between py-2">
       {/* 좌측 */}
       <div className="flex flex-col gap-4">
         <div className="flex items-center gap-2">
@@ -47,10 +49,13 @@ export default async function CommunityComment({
 
       {/* 우측 */}
       <div className="flex flex-col items-end justify-between">
-        {/* TODO: 기능, 인자 어떻게 처리할지 결정하기 */}
         {/* 본인일 때: 관리 메뉴 */}
         {isAuthenticated && isAuthor && (
-          <CommentActionMenu postId={postId} commentId={comment.id} />
+          <CommentActionMenu
+            postId={postId}
+            commentId={comment.id}
+            currentPage={currentPage}
+          />
         )}
 
         {/* 타인일 때: 신고 버튼 */}

--- a/src/widgets/community-comments/ui/CommunityComments.tsx
+++ b/src/widgets/community-comments/ui/CommunityComments.tsx
@@ -29,6 +29,7 @@ export default async function CommunityComments({
               comment={comment}
               userId={user?.id}
               postId={postId}
+              currentPage={page}
             />
           ))}
         </ul>

--- a/src/widgets/community-post/ui/CommunityPost.tsx
+++ b/src/widgets/community-post/ui/CommunityPost.tsx
@@ -1,9 +1,6 @@
-// import { cn } from '@/shared/lib/cn'
 import Image from 'next/image'
 import getPost from '@/widgets/community-post/api/getPost'
-// import { Button } from '@/shared/ui/Button'
 import PostStats from '@/entities/post/ui/PostStats'
-// import ActionDropdown from '@/shared/ui/ActionDropdown'
 import PostActionMenu from '@/features/community-post-manage/ui/PostActionMenu'
 import { MessageSquare } from 'lucide-react'
 import { getUser } from '@/shared/api/getUser'
@@ -11,6 +8,7 @@ import { notFound } from 'next/navigation'
 import { formatCommunityDate } from '@/shared/lib/date'
 import PostLikeButton from '@/features/community-post-like/ui/PostLikeButton'
 import PostReportButton from '@/features/community-report/ui/PostReportButton'
+import TextViewer from '@/shared/ui/text-editor/TextViewer'
 
 interface CommunityPostProps {
   id: number
@@ -80,8 +78,7 @@ export default async function CommunityPost({ id }: CommunityPostProps) {
       {/* 본문 */}
       <section>
         {/* 내용 */}
-        {/* TODO: 팁탭 에디터 뷰어 추가 */}
-        <div className="py-8">{post.content}</div>
+        <TextViewer content={post.content} />
 
         {/* 버튼: (좋아요, 신고하기), 댓글 수 */}
         <div className="flex items-end justify-between py-4">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #123 

## 📝작업 내용

- 텍스트 에디터 뷰어
- 게시글 신고하기 모달 (인풋)
- 댓글 신고하기 모달 (인풋)
- 공유하기 (URL 클립보드에 저장 + 토스트)

## 🖼️스크린샷

<img width="2456" height="1644" alt="image" src="https://github.com/user-attachments/assets/e9ec266c-96cc-49a4-bd39-64d023e2ecfe" />


## 💬리뷰 요구사항 (선택)

아, 어드민 용으로는 안되어 있는데 저희 어드민 가나여? 아예 버려졌나여?

## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
