### PR TITLE
[Feature] 로그아웃 시 채팅방 퇴장 처리

### DIFF
--- a/src/features/auth-logout/hook/useLogoutMutation.ts
+++ b/src/features/auth-logout/hook/useLogoutMutation.ts
@@ -4,6 +4,10 @@ import { useMutation } from '@tanstack/react-query'
 import { usePathname } from 'next/navigation'
 import { api } from '@/shared/api/client'
 import { clearAuthClientState } from '@/entities/session/lib/clear-session'
+import useChatCleanup from '@/entities/chat-room/model/useChatCleanup'
+import useMessageCleanup from '@/entities/message/model/useMessageCleanup'
+import { toast } from 'sonner'
+import { useChatStore } from '@/entities/chat-room/model/store'
 
 type LogoutOptions = {
   allDevices?: boolean
@@ -15,6 +19,9 @@ const isProtectedPath = (pathname?: string) =>
 
 export const useLogoutMutation = () => {
   const pathname = usePathname()
+  const enteredRoomId = useChatStore((state) => state.enteredRoomId)
+  const { cleanup: cleanupChat } = useChatCleanup()
+  const { cleanup: cleanupMessage } = useMessageCleanup()
 
   return useMutation({
     mutationFn: async (opts: LogoutOptions) => {
@@ -27,14 +34,21 @@ export const useLogoutMutation = () => {
       // TODO: API 연동 시 return api.post('/api/v1/auth/logout', { all_devices: opts.allDevices ?? false })
     },
 
-    onSuccess: (_data, opts: LogoutOptions) => {
+    onSuccess: async (_data, opts: LogoutOptions) => {
+      try {
+        if (enteredRoomId) {
+          cleanupMessage(enteredRoomId)
+          await cleanupChat(enteredRoomId)
+        }
+      } catch (error) {
+        console.error(`[Chat cleanup Error]\n${error}`)
+      }
       clearAuthClientState()
+
       const fallback = isProtectedPath(pathname) ? '/login' : '/'
       const to = opts?.redirectTo ?? fallback
       window.location.replace(to)
     },
-    onError: () => {
-      alert('로그아웃에 실패했습니다. 다시 시도해 주세요.')
-    },
+    onError: () => toast.error('로그아웃에 실패했습니다. 다시 시도해 주세요.'),
   })
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #133

## 📝작업 내용

> 로그아웃 시 채팅방 퇴장 처리
- 로그아웃 시 채팅방 퇴장 처리
- 로그아웃 에러 발생 시 alert → toast로 변경

## 🖼️스크린샷

https://github.com/user-attachments/assets/b3d92c75-114f-4617-89c9-0b53cc582299

## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
