### PR TITLE
[Feature] 비로그인 유저 접근 제한 페이지 설정

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+export const config = {
+  matcher: [
+    '/community/:id/edit',
+    '/community/write',
+    '/chat/:roomId',
+    '/mypage/:path*',
+  ],
+}
+
+export function proxy(request: NextRequest) {
+  const isLoggedIn = request.cookies.has('access')
+
+  if (isLoggedIn) return NextResponse.next()
+  return NextResponse.redirect(new URL('/auth/login', request.url))
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #135

## 📝작업 내용

> 비로그인 유저 접근 제한 페이지 설정
- 비로그인 유저의 접근을 제한한 페이지는 다음과 같습니다.
  - 게시글 수정 페이지
  - 게시글 작성 페이지
  - 채팅방 상세 페이지
  - 마이페이지

## 🖼️스크린샷

https://github.com/user-attachments/assets/3b4cf692-4dd2-4544-86af-abf668911a3f

## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
