### PR TITLE
[Feature] 마이페이지 리팩토링 (#141)

### DIFF
--- a/src/entities/mypage/api/my-likes-api.ts
+++ b/src/entities/mypage/api/my-likes-api.ts
@@ -2,74 +2,99 @@ import { api } from '@/shared/api/client'
 import type { PageParams } from '@/entities/mypage/model/common-schema'
 import { GetLikesResponseSchema } from '@/entities/mypage/model/my-likes-schema'
 
+type UnknownRecord = Record<string, unknown>
+
+const isPlainObject = (value: unknown): value is UnknownRecord => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+const unwrapResponseData = (responseBody: unknown): unknown => {
+  if (isPlainObject(responseBody) && isPlainObject(responseBody.data)) {
+    return responseBody.data
+  }
+
+  return responseBody
+}
+
+const normalizePagination = (
+  paginationResponse: unknown,
+  fallbackParams: PageParams
+) => {
+  const paginationObject = isPlainObject(paginationResponse)
+    ? paginationResponse
+    : {}
+
+  const page =
+    typeof paginationObject.current_page === 'number'
+      ? paginationObject.current_page
+      : typeof paginationObject.page === 'number'
+        ? paginationObject.page
+        : fallbackParams.page
+
+  const rawTotalPages =
+    typeof paginationObject.total_pages === 'number'
+      ? paginationObject.total_pages
+      : typeof paginationObject.totalPages === 'number'
+        ? paginationObject.totalPages
+        : 1
+
+  const totalPages = rawTotalPages === 0 ? 1 : rawTotalPages
+
+  const totalCount =
+    typeof paginationObject.total_count === 'number'
+      ? paginationObject.total_count
+      : typeof paginationObject.totalCount === 'number'
+        ? paginationObject.totalCount
+        : 0
+
+  const hasNext =
+    typeof paginationObject.has_next === 'boolean'
+      ? paginationObject.has_next
+      : typeof paginationObject.hasNext === 'boolean'
+        ? paginationObject.hasNext
+        : false
+
+  return {
+    page,
+    size: fallbackParams.size,
+    totalCount,
+    totalPages,
+    hasNext,
+  }
+}
+
+const normalizeLikesResponse = (
+  responseBody: unknown,
+  requestParams: PageParams
+) => {
+  const unwrappedData = unwrapResponseData(responseBody)
+
+  if (
+    isPlainObject(unwrappedData) &&
+    Array.isArray(unwrappedData.liked_posts)
+  ) {
+    return {
+      posts: unwrappedData.liked_posts,
+      pagination: normalizePagination(unwrappedData.pagination, requestParams),
+    }
+  }
+
+  if (isPlainObject(unwrappedData) && Array.isArray(unwrappedData.posts)) {
+    return {
+      posts: unwrappedData.posts,
+      pagination: normalizePagination(unwrappedData.pagination, requestParams),
+    }
+  }
+
+  throw new Error('getLikesApi: 응답 형식을 해석할 수 없습니다.')
+}
+
 export const getLikesApi = async (params: PageParams) => {
-  const res = await api.get('/me/profile/liked-posts', { params })
-  let data: unknown = res.data
+  const response = await api.get('/me/profile/liked-posts', {
+    params,
+  })
 
-  if (data == null || data === '') {
-    throw new Error('응답 바디가 비어있습니다.')
-  }
+  const normalizedResponse = normalizeLikesResponse(response.data, params)
 
-  if (typeof data === 'object') {
-    const maybe = data as Record<string, unknown>
-    const inner =
-      maybe && typeof maybe.data === 'object' && maybe.data !== null
-        ? (maybe.data as Record<string, unknown>)
-        : maybe
-
-    const backfillPagination = (value: unknown) => {
-      if (value == null || typeof value !== 'object') return value
-      const obj = value as Record<string, unknown>
-      const pagination = obj.pagination
-      if (pagination == null || typeof pagination !== 'object') return value
-      const paginationRecord = pagination as Record<string, unknown>
-      const page = paginationRecord.page
-      const size = paginationRecord.size
-
-      if (typeof page === 'number' && typeof size === 'number') return value
-
-      return {
-        ...obj,
-        pagination: {
-          ...(typeof pagination === 'object' ? (pagination as object) : {}),
-          page: typeof page === 'number' ? page : params.page,
-          size: typeof size === 'number' ? size : params.size,
-        },
-      }
-    }
-
-    if (maybe && typeof maybe.data === 'object' && maybe.data !== null) {
-      data = {
-        ...maybe,
-        data: backfillPagination(maybe.data),
-      }
-    } else {
-      data = backfillPagination(maybe)
-    }
-
-    if (!('posts' in inner) && typeof maybe.message === 'string') {
-      const message = maybe.message.trim()
-
-      // 백엔드가 "빈 목록"을 message-only로 주는 케이스는 정상(empty)로 처리
-      if (
-        message === '좋아한 게시글이 없습니다.' ||
-        message === '좋아요한 게시글이 없습니다.'
-      ) {
-        return {
-          posts: [],
-          pagination: {
-            page: params.page,
-            size: params.size,
-            totalCount: 0,
-            totalPages: 1,
-            hasNext: false,
-          },
-        }
-      }
-
-      throw new Error(message)
-    }
-  }
-
-  return GetLikesResponseSchema.parse(data)
+  return GetLikesResponseSchema.parse(normalizedResponse)
 }

--- a/src/entities/mypage/api/post-detail-api.ts
+++ b/src/entities/mypage/api/post-detail-api.ts
@@ -1,0 +1,6 @@
+import { api } from '@/shared/api/client'
+
+export const getPostDetailApi = async (postId: number): Promise<unknown> => {
+  const res = await api.get(`/posts/${postId}`)
+  return res.data
+}

--- a/src/entities/mypage/model/my-comments-schema.ts
+++ b/src/entities/mypage/model/my-comments-schema.ts
@@ -4,7 +4,10 @@ import { PaginationSchema } from '@/entities/mypage/model/common-schema'
 export const MyCommentSchema = z
   .object({
     id: z.number(),
+
     content: z.string().nullable().optional(),
+    content_preview: z.string().nullable().optional(),
+    contentPreview: z.string().nullable().optional(),
 
     createdAt: z.string().optional(),
     created_at: z.string().optional(),
@@ -18,12 +21,17 @@ export const MyCommentSchema = z
     post_title: z.string().nullable().optional(),
   })
   .transform((v) => {
+    const isDeleted = v.is_deleted === true
+
+    const content = v.content ?? v.contentPreview ?? v.content_preview ?? null
+
+    const postId = isDeleted ? null : (v.postId ?? v.post_id ?? null)
+
     return {
       id: v.id,
-      content: v.content ?? null,
+      content,
       createdAt: v.createdAt ?? v.created_at ?? '',
-      is_deleted: v.is_deleted,
-      postId: v.postId ?? v.post_id ?? null,
+      postId,
       postTitle: v.postTitle ?? v.post_title ?? null,
     }
   })

--- a/src/features/mypage/hook/useMyPageBaselist.ts
+++ b/src/features/mypage/hook/useMyPageBaselist.ts
@@ -19,6 +19,15 @@ type UserLike = {
 type MyPostsItem = GetMyPostsResponse['posts'][number]
 type LikesItem = GetLikesResponse['posts'][number]
 
+type CountFields = {
+  viewCount?: number
+  likeCount?: number
+  commentCount?: number
+  view_count?: number
+  like_count?: number
+  comment_count?: number
+}
+
 export function useMyPageBasePosts(params: {
   user: UserLike
   posts: GetMyPostsResponse['posts'] | undefined
@@ -33,15 +42,17 @@ export function useMyPageBasePosts(params: {
       const { date, time } = formatDateParts(postItem.createdAt)
       const thumb = extractFirstImageUrl(pickContentPreview(postItem))
 
+      const counts = postItem as unknown as CountFields
+
       return {
         id: postItem.id,
         author,
         date,
         time,
         title: postItem.title,
-        views: 0,
-        likes: 0,
-        comments: 0,
+        views: counts.viewCount ?? counts.view_count ?? 0,
+        likes: counts.likeCount ?? counts.like_count ?? 0,
+        comments: counts.commentCount ?? counts.comment_count ?? 0,
         avatar: safeAvatar,
         thumbnail: thumb,
         board: 'free',
@@ -67,15 +78,17 @@ export function useMyPageBaseLikedPosts(params: {
       const { date, time } = formatDateParts(createdAt)
       const thumb = extractFirstImageUrl(pickContentPreview(postItem))
 
+      const counts = postItem as unknown as CountFields
+
       return {
         id: postItem.id,
         author,
         date,
         time,
         title: postItem.title,
-        views: 0,
-        likes: 0,
-        comments: 0,
+        views: counts.viewCount ?? counts.view_count ?? 0,
+        likes: counts.likeCount ?? counts.like_count ?? 0,
+        comments: counts.commentCount ?? counts.comment_count ?? 0,
         avatar: safeAvatar,
         thumbnail: thumb,
         board: 'free',

--- a/src/features/mypage/hook/useMyPageBaselist.ts
+++ b/src/features/mypage/hook/useMyPageBaselist.ts
@@ -1,0 +1,87 @@
+import { useMemo } from 'react'
+
+import type { MyPagePostItem } from '@/entities/mypage/model/mypage-ui-types'
+import type { GetMyPostsResponse } from '@/entities/mypage/model/my-post-schema'
+import type { GetLikesResponse } from '@/entities/mypage/model/my-likes-schema'
+
+import { formatDateParts } from '@/features/mypage/lib/data-kst'
+import { extractFirstImageUrl } from '@/features/mypage/lib/extract-first-image-url'
+import {
+  DEFAULT_AVATAR,
+  pickContentPreview,
+} from '@/features/mypage/lib/mypage-content-picker'
+
+type UserLike = {
+  nickname?: string | null
+  profileImageUrl?: string | null
+} | null
+
+type MyPostsItem = GetMyPostsResponse['posts'][number]
+type LikesItem = GetLikesResponse['posts'][number]
+
+export function useMyPageBasePosts(params: {
+  user: UserLike
+  posts: GetMyPostsResponse['posts'] | undefined
+}) {
+  const { user, posts } = params
+
+  const basePosts = useMemo<MyPagePostItem[]>(() => {
+    const author = user?.nickname ?? ''
+    const safeAvatar = user?.profileImageUrl ?? DEFAULT_AVATAR
+
+    return (posts ?? []).map((postItem: MyPostsItem) => {
+      const { date, time } = formatDateParts(postItem.createdAt)
+      const thumb = extractFirstImageUrl(pickContentPreview(postItem))
+
+      return {
+        id: postItem.id,
+        author,
+        date,
+        time,
+        title: postItem.title,
+        views: 0,
+        likes: 0,
+        comments: 0,
+        avatar: safeAvatar,
+        thumbnail: thumb,
+        board: 'free',
+      }
+    })
+  }, [posts, user?.nickname, user?.profileImageUrl])
+
+  return { basePosts }
+}
+
+export function useMyPageBaseLikedPosts(params: {
+  user: UserLike
+  posts: GetLikesResponse['posts'] | undefined
+}) {
+  const { user, posts } = params
+
+  const baseLikedPosts = useMemo<MyPagePostItem[]>(() => {
+    const author = user?.nickname ?? ''
+    const safeAvatar = user?.profileImageUrl ?? DEFAULT_AVATAR
+
+    return (posts ?? []).map((postItem: LikesItem) => {
+      const createdAt = postItem.likedAt ?? postItem.createdAt ?? ''
+      const { date, time } = formatDateParts(createdAt)
+      const thumb = extractFirstImageUrl(pickContentPreview(postItem))
+
+      return {
+        id: postItem.id,
+        author,
+        date,
+        time,
+        title: postItem.title,
+        views: 0,
+        likes: 0,
+        comments: 0,
+        avatar: safeAvatar,
+        thumbnail: thumb,
+        board: 'free',
+      }
+    })
+  }, [posts, user?.nickname, user?.profileImageUrl])
+
+  return { baseLikedPosts }
+}

--- a/src/features/mypage/hook/useMyPageCommentList.ts
+++ b/src/features/mypage/hook/useMyPageCommentList.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react'
+
+import type { MyCommentItem } from '@/entities/mypage/model/mypage-ui-types'
+import type { GetMyCommentsResponse } from '@/entities/mypage/model/my-comments-schema'
+
+type CommentResponseItem = GetMyCommentsResponse['comments'][number]
+
+export function useMyPageCommentsList(
+  comments: GetMyCommentsResponse['comments'] | undefined
+) {
+  const mappedComments = useMemo<MyCommentItem[]>(() => {
+    const items = comments ?? []
+
+    return items.map((commentItem: CommentResponseItem) => ({
+      commentId: String(commentItem.id),
+      postId: commentItem.postId == null ? null : String(commentItem.postId),
+      postTitle: commentItem.postTitle ?? null,
+      content: commentItem.content ?? null,
+      createdAt: commentItem.createdAt,
+      board: null,
+    }))
+  }, [comments])
+
+  return { comments: mappedComments }
+}

--- a/src/features/mypage/hook/useMyPageController.ts
+++ b/src/features/mypage/hook/useMyPageController.ts
@@ -1,20 +1,7 @@
 'use client'
 
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from 'react'
-import { toast } from 'sonner'
-import { useQueries } from '@tanstack/react-query'
-
+import { useMemo, useState, useSyncExternalStore } from 'react'
 import type { SortOption } from '@/features/mypage/ui/PostFilter'
-import type {
-  MyCommentItem,
-  MyPagePostItem,
-} from '@/entities/mypage/model/mypage-ui-types'
 
 import { useSessionStore } from '@/entities/session/store/session-store'
 
@@ -23,78 +10,27 @@ import { useMyComments } from '@/features/mypage/hook/useMyComments'
 import { useLikedPosts } from '@/features/mypage/hook/useLikes'
 import { useDeleteMyPosts } from '@/features/mypage/hook/useDeleteMyPost'
 import { useDeleteMyComments } from '@/features/mypage/hook/useDeleteMyComments'
-import { useTimelineHistory } from '@/features/mypage/hook/useTimeline'
 
-import { normalize } from '@/features/mypage/lib/text'
+import { useMyPageTimeline } from '@/features/mypage/hook/useMyPageTimeline'
+import { useMyPageProfile } from '@/features/mypage/hook/useMyPageProfile'
 import {
-  addDays,
-  formatDateParts,
-  startOfKoreaStandardTimeDay,
-  toKoreanDay,
-  toMonthDay,
-  toYearMonthDay,
-} from '@/features/mypage/lib/data-kst'
-
-import type { TimelineItem } from '@/features/mypage/ui/TimeLine'
-import { extractFirstImageUrl } from '@/features/mypage/lib/extract-first-image-url'
-import { getPostDetailApi } from '@/entities/mypage/api/post-detail-api'
+  useMyPageBaseLikedPosts,
+  useMyPageBasePosts,
+} from '@/features/mypage/hook/useMyPageBaselist'
+import {
+  useMyPageLikedPostsWithDetailThumbnail,
+  useMyPagePostsWithDetailThumbnail,
+} from '@/features/mypage/hook/useMyPageDetailThumbnailMerge'
+import { useMyPageCommentsList } from '@/features/mypage/hook/useMyPageCommentList'
+import {
+  useMyPageFilteredComments,
+  useMyPageFilteredLikes,
+  useMyPageFilteredPosts,
+} from '@/features/mypage/hook/useMyPageFilteredList'
+import { useMyPageErrorToast } from '@/features/mypage/hook/useMyPageErrorToast'
+import { toast } from 'sonner'
 
 type TabType = 'post' | 'comment' | 'like'
-
-const DEFAULT_AVATAR = '/images/profiles/default-1.webp'
-
-function pickString(obj: unknown, key: string): string | undefined {
-  if (!obj || typeof obj !== 'object') return undefined
-  const rec = obj as Record<string, unknown>
-  const value = rec[key]
-  return typeof value === 'string' ? value : undefined
-}
-
-function pickFirstString(obj: unknown, keys: string[]): string {
-  for (const k of keys) {
-    const v = pickString(obj, k)
-    if (v) return v
-  }
-  return ''
-}
-
-function pickContentPreview(obj: unknown): string {
-  return pickFirstString(obj, ['contentPreview', 'content_preview'])
-}
-
-function pickDetailContent(detail: unknown): string {
-  return pickFirstString(detail, [
-    'content',
-    'content_preview',
-    'contentPreview',
-  ])
-}
-
-function pickDetailThumbnail(detail: unknown): string {
-  if (!detail || typeof detail !== 'object') return ''
-  const rec = detail as Record<string, unknown>
-
-  const thumb = rec['thumbnail_url']
-  if (typeof thumb === 'string' && thumb.trim()) return thumb
-
-  const images = rec['images']
-  if (Array.isArray(images) && images.length > 0) {
-    const first = images[0]
-    if (typeof first === 'string' && first.trim()) return first
-    if (first && typeof first === 'object') {
-      const f = first as Record<string, unknown>
-      const url =
-        (typeof f['url'] === 'string' && f['url']) ||
-        (typeof f['src'] === 'string' && f['src']) ||
-        (typeof f['image_url'] === 'string' && f['image_url']) ||
-        ''
-      if (url) return url
-    }
-  }
-
-  const content = pickDetailContent(detail)
-  return extractFirstImageUrl(content)
-}
 
 export function useMyPageController() {
   const [tab, setTab] = useState<TabType>('post')
@@ -135,263 +71,53 @@ export function useMyPageController() {
   const deleteMyPosts = useDeleteMyPosts()
   const deleteMyComments = useDeleteMyComments()
 
-  const lastErrorKeyRef = useRef<string | null>(null)
+  const { timeline } = useMyPageTimeline(isClient)
+  const { profile } = useMyPageProfile(user)
 
-  const timelineHistoryQuery = useTimelineHistory(isClient)
-
-  const noHistoryToastOnceRef = useRef(false)
-  useEffect(() => {
-    if (!timelineHistoryQuery.isSuccess) return
-    if (noHistoryToastOnceRef.current) return
-
-    const results = timelineHistoryQuery.data?.results ?? []
-    if (results.length === 0) {
-      noHistoryToastOnceRef.current = true
-      toast('아직 출석 기록이 없습니다')
-    }
-  }, [timelineHistoryQuery.isSuccess, timelineHistoryQuery.data?.results])
-
-  const timeline = useMemo<TimelineItem[]>(() => {
-    const today = startOfKoreaStandardTimeDay()
-    const results = timelineHistoryQuery.data?.results ?? []
-
-    const submittedMap = new Map<string, boolean>()
-    for (const r of results) submittedMap.set(r.date, !!r.is_submitted)
-
-    const items: TimelineItem[] = []
-    for (let d = -3; d <= 3; d += 1) {
-      const dateObject = addDays(today, d)
-      const ymd = toYearMonthDay(dateObject)
-      const submitted = submittedMap.get(ymd) ?? false
-
-      let status: TimelineItem['status'] = 'upcoming'
-      if (d > 0) status = 'upcoming'
-      else if (d === 0) status = submitted ? 'done' : 'go'
-      else status = submitted ? 'done' : 'fail'
-
-      items.push({
-        date: toMonthDay(dateObject),
-        day: toKoreanDay(dateObject),
-        status,
-      })
-    }
-    return items
-  }, [timelineHistoryQuery.data?.results])
-
-  const profile = useMemo(() => {
-    return {
-      nickname: user?.nickname ?? '',
-      email: user?.email ?? '',
-      joinedAt: '-',
-      profileImageSrc: user?.profileImageUrl ?? null,
-      balloonLeft: {
-        title: '오늘도 힘내봐요!',
-        subtitle: 'Hazlo lo mejor que puedas hoy también',
-      },
-      balloonRight: { title: 'STUDY GO !' },
-    }
-  }, [user?.email, user?.nickname, user?.profileImageUrl])
-
-  const basePosts = useMemo<MyPagePostItem[]>(() => {
-    const author = user?.nickname ?? ''
-    const safeAvatar = user?.profileImageUrl ?? DEFAULT_AVATAR
-
-    return (myPostsQuery.data?.posts ?? []).map((p) => {
-      const { date, time } = formatDateParts(p.createdAt)
-      const thumb = extractFirstImageUrl(pickContentPreview(p))
-      return {
-        id: p.id,
-        author,
-        date,
-        time,
-        title: p.title,
-        views: 0,
-        likes: 0,
-        comments: 0,
-        avatar: safeAvatar,
-        thumbnail: thumb,
-        board: 'free',
-      }
-    })
-  }, [myPostsQuery.data?.posts, user?.nickname, user?.profileImageUrl])
-
-  const baseLikedPosts = useMemo<MyPagePostItem[]>(() => {
-    const author = user?.nickname ?? ''
-    const safeAvatar = user?.profileImageUrl ?? DEFAULT_AVATAR
-
-    return (likedPostsQuery.data?.posts ?? []).map((p) => {
-      const createdAt = p.likedAt ?? p.createdAt ?? ''
-      const { date, time } = formatDateParts(createdAt)
-      const thumb = extractFirstImageUrl(pickContentPreview(p))
-      return {
-        id: p.id,
-        author,
-        date,
-        time,
-        title: p.title,
-        views: 0,
-        likes: 0,
-        comments: 0,
-        avatar: safeAvatar,
-        thumbnail: thumb,
-        board: 'free',
-      }
-    })
-  }, [likedPostsQuery.data?.posts, user?.nickname, user?.profileImageUrl])
-
-  const needDetailPostIds = useMemo(() => {
-    if (tab !== 'post') return []
-    return basePosts
-      .filter((p) => !p.thumbnail)
-      .map((p) => p.id)
-      .slice(0, 10)
-  }, [tab, basePosts])
-
-  const needDetailLikeIds = useMemo(() => {
-    if (tab !== 'like') return []
-    return baseLikedPosts
-      .filter((p) => !p.thumbnail)
-      .map((p) => p.id)
-      .slice(0, 10)
-  }, [tab, baseLikedPosts])
-
-  const postDetailQueries = useQueries({
-    queries: needDetailPostIds.map((id) => ({
-      queryKey: ['post-detail', id],
-      queryFn: () => getPostDetailApi(id),
-      enabled: isClient && tab === 'post',
-      staleTime: 1000 * 60 * 10,
-    })),
+  const { basePosts } = useMyPageBasePosts({
+    user,
+    posts: myPostsQuery.data?.posts,
+  })
+  const { baseLikedPosts } = useMyPageBaseLikedPosts({
+    user,
+    posts: likedPostsQuery.data?.posts,
   })
 
-  const likeDetailQueries = useQueries({
-    queries: needDetailLikeIds.map((id) => ({
-      queryKey: ['post-detail', id],
-      queryFn: () => getPostDetailApi(id),
-      enabled: isClient && tab === 'like',
-      staleTime: 1000 * 60 * 10,
-    })),
-  })
-
-  const posts = useMemo<MyPagePostItem[]>(() => {
-    if (tab !== 'post') return basePosts
-
-    const map = new Map<number, string>()
-    for (let i = 0; i < needDetailPostIds.length; i += 1) {
-      const id = needDetailPostIds[i]
-      const detail = postDetailQueries[i]?.data
-      if (!detail) continue
-      const thumb = pickDetailThumbnail(detail)
-      if (thumb) map.set(id, thumb)
-    }
-
-    return basePosts.map((p) => ({
-      ...p,
-      thumbnail: p.thumbnail || map.get(p.id) || '',
-    }))
-  }, [tab, basePosts, needDetailPostIds, postDetailQueries])
-
-  const likedPosts = useMemo<MyPagePostItem[]>(() => {
-    if (tab !== 'like') return baseLikedPosts
-
-    const map = new Map<number, string>()
-    for (let i = 0; i < needDetailLikeIds.length; i += 1) {
-      const id = needDetailLikeIds[i]
-      const detail = likeDetailQueries[i]?.data
-      if (!detail) continue
-      const thumb = pickDetailThumbnail(detail)
-      if (thumb) map.set(id, thumb)
-    }
-
-    return baseLikedPosts.map((p) => ({
-      ...p,
-      thumbnail: p.thumbnail || map.get(p.id) || '',
-    }))
-  }, [tab, baseLikedPosts, needDetailLikeIds, likeDetailQueries])
-
-  const comments = useMemo<MyCommentItem[]>(() => {
-    const items = myCommentsQuery.data?.comments ?? []
-    return items.map((c) => ({
-      commentId: String(c.id),
-      postId: c.postId == null ? null : String(c.postId),
-      postTitle: c.postTitle ?? null,
-      content: c.content ?? null,
-      createdAt: c.createdAt,
-      board: null,
-    }))
-  }, [myCommentsQuery.data?.comments])
-
-  const filteredPosts = useMemo(() => {
-    const b = normalize(selectedBoard)
-    const s = normalize(search)
-    return posts.filter((p) => {
-      const okBoard = !b || normalize(p.board) === b
-      const okSearch =
-        !s || normalize(p.title).includes(s) || normalize(p.author).includes(s)
-      return okBoard && okSearch
-    })
-  }, [posts, selectedBoard, search])
-
-  const filteredLikes = useMemo(() => {
-    const b = normalize(selectedBoard)
-    const s = normalize(search)
-    return likedPosts.filter((p) => {
-      const okBoard = !b || normalize(p.board) === b
-      const okSearch =
-        !s || normalize(p.title).includes(s) || normalize(p.author).includes(s)
-      return okBoard && okSearch
-    })
-  }, [likedPosts, selectedBoard, search])
-
-  const filteredComments = useMemo(() => {
-    const b = normalize(selectedBoard)
-    const s = normalize(search)
-    return comments.filter((c) => {
-      const okBoard = !b || normalize(c.board) === b
-      const okSearch =
-        !s ||
-        normalize(c.postTitle).includes(s) ||
-        normalize(c.content).includes(s)
-      return okBoard && okSearch
-    })
-  }, [comments, selectedBoard, search])
-
-  useEffect(() => {
-    const isError =
-      (tab === 'post' && myPostsQuery.isError) ||
-      (tab === 'comment' && myCommentsQuery.isError) ||
-      (tab === 'like' && likedPostsQuery.isError)
-
-    if (!isError) {
-      lastErrorKeyRef.current = null
-      return
-    }
-
-    const error =
-      (tab === 'post' && myPostsQuery.error) ||
-      (tab === 'comment' && myCommentsQuery.error) ||
-      (tab === 'like' && likedPostsQuery.error)
-
-    const message =
-      error instanceof Error ? error.message : error ? String(error) : ''
-    const key = `${tab}:${message}`
-    if (lastErrorKeyRef.current === key) return
-    lastErrorKeyRef.current = key
-
-    toast.error(
-      message
-        ? `마이페이지 데이터를 불러오지 못했습니다. (${message})`
-        : '마이페이지 데이터를 불러오지 못했습니다.'
-    )
-  }, [
+  const { posts } = useMyPagePostsWithDetailThumbnail({
     tab,
-    myPostsQuery.error,
-    myPostsQuery.isError,
-    myCommentsQuery.error,
-    myCommentsQuery.isError,
-    likedPostsQuery.error,
-    likedPostsQuery.isError,
-  ])
+    isClient,
+    basePosts,
+  })
+  const { likedPosts } = useMyPageLikedPostsWithDetailThumbnail({
+    tab,
+    isClient,
+    baseLikedPosts,
+  })
+
+  const { comments } = useMyPageCommentsList(myCommentsQuery.data?.comments)
+
+  const { filteredPosts } = useMyPageFilteredPosts({
+    posts,
+    selectedBoard,
+    search,
+  })
+  const { filteredLikes } = useMyPageFilteredLikes({
+    likedPosts,
+    selectedBoard,
+    search,
+  })
+  const { filteredComments } = useMyPageFilteredComments({
+    comments,
+    selectedBoard,
+    search,
+  })
+
+  useMyPageErrorToast({
+    tab,
+    myPostsQuery,
+    myCommentsQuery,
+    likedPostsQuery,
+  })
 
   const handleChangeTab = (nextTab: TabType) => {
     setTab(nextTab)

--- a/src/features/mypage/hook/useMyPageController.ts
+++ b/src/features/mypage/hook/useMyPageController.ts
@@ -8,6 +8,7 @@ import {
   useSyncExternalStore,
 } from 'react'
 import { toast } from 'sonner'
+import { useQueries } from '@tanstack/react-query'
 
 import type { SortOption } from '@/features/mypage/ui/PostFilter'
 import type {
@@ -35,11 +36,65 @@ import {
 } from '@/features/mypage/lib/data-kst'
 
 import type { TimelineItem } from '@/features/mypage/ui/TimeLine'
+import { extractFirstImageUrl } from '@/features/mypage/lib/extract-first-image-url'
+import { getPostDetailApi } from '@/entities/mypage/api/post-detail-api'
 
 type TabType = 'post' | 'comment' | 'like'
 
-const DEFAULT_THUMBNAIL = '/images/mypage/post-example.png'
 const DEFAULT_AVATAR = '/images/profiles/default-1.webp'
+
+function pickString(obj: unknown, key: string): string | undefined {
+  if (!obj || typeof obj !== 'object') return undefined
+  const rec = obj as Record<string, unknown>
+  const value = rec[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+function pickFirstString(obj: unknown, keys: string[]): string {
+  for (const k of keys) {
+    const v = pickString(obj, k)
+    if (v) return v
+  }
+  return ''
+}
+
+function pickContentPreview(obj: unknown): string {
+  return pickFirstString(obj, ['contentPreview', 'content_preview'])
+}
+
+function pickDetailContent(detail: unknown): string {
+  return pickFirstString(detail, [
+    'content',
+    'content_preview',
+    'contentPreview',
+  ])
+}
+
+function pickDetailThumbnail(detail: unknown): string {
+  if (!detail || typeof detail !== 'object') return ''
+  const rec = detail as Record<string, unknown>
+
+  const thumb = rec['thumbnail_url']
+  if (typeof thumb === 'string' && thumb.trim()) return thumb
+
+  const images = rec['images']
+  if (Array.isArray(images) && images.length > 0) {
+    const first = images[0]
+    if (typeof first === 'string' && first.trim()) return first
+    if (first && typeof first === 'object') {
+      const f = first as Record<string, unknown>
+      const url =
+        (typeof f['url'] === 'string' && f['url']) ||
+        (typeof f['src'] === 'string' && f['src']) ||
+        (typeof f['image_url'] === 'string' && f['image_url']) ||
+        ''
+      if (url) return url
+    }
+  }
+
+  const content = pickDetailContent(detail)
+  return extractFirstImageUrl(content)
+}
 
 export function useMyPageController() {
   const [tab, setTab] = useState<TabType>('post')
@@ -53,7 +108,6 @@ export function useMyPageController() {
 
   const sessionUser = useSessionStore((state) => state.user)
 
-  // 기존 동작 유지: SSR 시점에는 user=null 유지
   const isClient = useSyncExternalStore(
     (onStoreChange) => {
       queueMicrotask(onStoreChange)
@@ -102,19 +156,17 @@ export function useMyPageController() {
     const results = timelineHistoryQuery.data?.results ?? []
 
     const submittedMap = new Map<string, boolean>()
-    for (const resultItem of results) {
-      submittedMap.set(resultItem.date, !!resultItem.is_submitted)
-    }
+    for (const r of results) submittedMap.set(r.date, !!r.is_submitted)
 
     const items: TimelineItem[] = []
-    for (let offsetDays = -3; offsetDays <= 3; offsetDays += 1) {
-      const dateObject = addDays(today, offsetDays)
-      const yearMonthDay = toYearMonthDay(dateObject)
-      const submitted = submittedMap.get(yearMonthDay) ?? false
+    for (let d = -3; d <= 3; d += 1) {
+      const dateObject = addDays(today, d)
+      const ymd = toYearMonthDay(dateObject)
+      const submitted = submittedMap.get(ymd) ?? false
 
       let status: TimelineItem['status'] = 'upcoming'
-      if (offsetDays > 0) status = 'upcoming'
-      else if (offsetDays === 0) status = submitted ? 'done' : 'go'
+      if (d > 0) status = 'upcoming'
+      else if (d === 0) status = submitted ? 'done' : 'go'
       else status = submitted ? 'done' : 'fail'
 
       items.push({
@@ -123,7 +175,6 @@ export function useMyPageController() {
         status,
       })
     }
-
     return items
   }, [timelineHistoryQuery.data?.results])
 
@@ -137,118 +188,171 @@ export function useMyPageController() {
         title: '오늘도 힘내봐요!',
         subtitle: 'Hazlo lo mejor que puedas hoy también',
       },
-      balloonRight: {
-        title: 'STUDY GO !',
-      },
+      balloonRight: { title: 'STUDY GO !' },
     }
   }, [user?.email, user?.nickname, user?.profileImageUrl])
 
-  const posts = useMemo<MyPagePostItem[]>(() => {
+  const basePosts = useMemo<MyPagePostItem[]>(() => {
     const author = user?.nickname ?? ''
-    const profileImageUrl = user?.profileImageUrl
-    const safeAvatar = profileImageUrl ?? DEFAULT_AVATAR
+    const safeAvatar = user?.profileImageUrl ?? DEFAULT_AVATAR
 
-    return (myPostsQuery.data?.posts ?? []).map((postItem) => {
-      const { date, time } = formatDateParts(postItem.createdAt)
+    return (myPostsQuery.data?.posts ?? []).map((p) => {
+      const { date, time } = formatDateParts(p.createdAt)
+      const thumb = extractFirstImageUrl(pickContentPreview(p))
       return {
-        id: postItem.id,
+        id: p.id,
         author,
         date,
         time,
-        title: postItem.title,
+        title: p.title,
         views: 0,
         likes: 0,
         comments: 0,
         avatar: safeAvatar,
-        thumbnail: DEFAULT_THUMBNAIL,
+        thumbnail: thumb,
         board: 'free',
       }
     })
   }, [myPostsQuery.data?.posts, user?.nickname, user?.profileImageUrl])
 
-  const likedPosts = useMemo<MyPagePostItem[]>(() => {
+  const baseLikedPosts = useMemo<MyPagePostItem[]>(() => {
     const author = user?.nickname ?? ''
-    const profileImageUrl = user?.profileImageUrl
-    const safeAvatar = profileImageUrl ?? DEFAULT_AVATAR
+    const safeAvatar = user?.profileImageUrl ?? DEFAULT_AVATAR
 
-    return (likedPostsQuery.data?.posts ?? []).map((postItem) => {
-      const createdAt = postItem.likedAt ?? postItem.createdAt ?? ''
+    return (likedPostsQuery.data?.posts ?? []).map((p) => {
+      const createdAt = p.likedAt ?? p.createdAt ?? ''
       const { date, time } = formatDateParts(createdAt)
+      const thumb = extractFirstImageUrl(pickContentPreview(p))
       return {
-        id: postItem.id,
+        id: p.id,
         author,
         date,
         time,
-        title: postItem.title,
+        title: p.title,
         views: 0,
         likes: 0,
         comments: 0,
         avatar: safeAvatar,
-        thumbnail: DEFAULT_THUMBNAIL,
+        thumbnail: thumb,
         board: 'free',
       }
     })
   }, [likedPostsQuery.data?.posts, user?.nickname, user?.profileImageUrl])
 
+  const needDetailPostIds = useMemo(() => {
+    if (tab !== 'post') return []
+    return basePosts
+      .filter((p) => !p.thumbnail)
+      .map((p) => p.id)
+      .slice(0, 10)
+  }, [tab, basePosts])
+
+  const needDetailLikeIds = useMemo(() => {
+    if (tab !== 'like') return []
+    return baseLikedPosts
+      .filter((p) => !p.thumbnail)
+      .map((p) => p.id)
+      .slice(0, 10)
+  }, [tab, baseLikedPosts])
+
+  const postDetailQueries = useQueries({
+    queries: needDetailPostIds.map((id) => ({
+      queryKey: ['post-detail', id],
+      queryFn: () => getPostDetailApi(id),
+      enabled: isClient && tab === 'post',
+      staleTime: 1000 * 60 * 10,
+    })),
+  })
+
+  const likeDetailQueries = useQueries({
+    queries: needDetailLikeIds.map((id) => ({
+      queryKey: ['post-detail', id],
+      queryFn: () => getPostDetailApi(id),
+      enabled: isClient && tab === 'like',
+      staleTime: 1000 * 60 * 10,
+    })),
+  })
+
+  const posts = useMemo<MyPagePostItem[]>(() => {
+    if (tab !== 'post') return basePosts
+
+    const map = new Map<number, string>()
+    for (let i = 0; i < needDetailPostIds.length; i += 1) {
+      const id = needDetailPostIds[i]
+      const detail = postDetailQueries[i]?.data
+      if (!detail) continue
+      const thumb = pickDetailThumbnail(detail)
+      if (thumb) map.set(id, thumb)
+    }
+
+    return basePosts.map((p) => ({
+      ...p,
+      thumbnail: p.thumbnail || map.get(p.id) || '',
+    }))
+  }, [tab, basePosts, needDetailPostIds, postDetailQueries])
+
+  const likedPosts = useMemo<MyPagePostItem[]>(() => {
+    if (tab !== 'like') return baseLikedPosts
+
+    const map = new Map<number, string>()
+    for (let i = 0; i < needDetailLikeIds.length; i += 1) {
+      const id = needDetailLikeIds[i]
+      const detail = likeDetailQueries[i]?.data
+      if (!detail) continue
+      const thumb = pickDetailThumbnail(detail)
+      if (thumb) map.set(id, thumb)
+    }
+
+    return baseLikedPosts.map((p) => ({
+      ...p,
+      thumbnail: p.thumbnail || map.get(p.id) || '',
+    }))
+  }, [tab, baseLikedPosts, needDetailLikeIds, likeDetailQueries])
+
   const comments = useMemo<MyCommentItem[]>(() => {
-    const commentItems = myCommentsQuery.data?.comments ?? []
-    return commentItems.map((commentItem) => {
-      return {
-        commentId: String(commentItem.id),
-        postId: commentItem.postId == null ? null : String(commentItem.postId),
-        postTitle: commentItem.postTitle ?? null,
-        content: commentItem.content ?? null,
-        createdAt: commentItem.createdAt,
-        board: null,
-      }
-    })
+    const items = myCommentsQuery.data?.comments ?? []
+    return items.map((c) => ({
+      commentId: String(c.id),
+      postId: c.postId == null ? null : String(c.postId),
+      postTitle: c.postTitle ?? null,
+      content: c.content ?? null,
+      createdAt: c.createdAt,
+      board: null,
+    }))
   }, [myCommentsQuery.data?.comments])
 
   const filteredPosts = useMemo(() => {
-    const normalizedBoard = normalize(selectedBoard)
-    const normalizedSearch = normalize(search)
-
-    return posts.filter((postItem) => {
-      const matchesBoard =
-        !normalizedBoard || normalize(postItem.board) === normalizedBoard
-      const matchesSearch =
-        !normalizedSearch ||
-        normalize(postItem.title).includes(normalizedSearch) ||
-        normalize(postItem.author).includes(normalizedSearch)
-
-      return matchesBoard && matchesSearch
+    const b = normalize(selectedBoard)
+    const s = normalize(search)
+    return posts.filter((p) => {
+      const okBoard = !b || normalize(p.board) === b
+      const okSearch =
+        !s || normalize(p.title).includes(s) || normalize(p.author).includes(s)
+      return okBoard && okSearch
     })
   }, [posts, selectedBoard, search])
 
   const filteredLikes = useMemo(() => {
-    const normalizedBoard = normalize(selectedBoard)
-    const normalizedSearch = normalize(search)
-
-    return likedPosts.filter((postItem) => {
-      const matchesBoard =
-        !normalizedBoard || normalize(postItem.board) === normalizedBoard
-      const matchesSearch =
-        !normalizedSearch ||
-        normalize(postItem.title).includes(normalizedSearch) ||
-        normalize(postItem.author).includes(normalizedSearch)
-
-      return matchesBoard && matchesSearch
+    const b = normalize(selectedBoard)
+    const s = normalize(search)
+    return likedPosts.filter((p) => {
+      const okBoard = !b || normalize(p.board) === b
+      const okSearch =
+        !s || normalize(p.title).includes(s) || normalize(p.author).includes(s)
+      return okBoard && okSearch
     })
   }, [likedPosts, selectedBoard, search])
 
   const filteredComments = useMemo(() => {
-    const normalizedBoard = normalize(selectedBoard)
-    const normalizedSearch = normalize(search)
-
-    return comments.filter((commentItem) => {
-      const matchesBoard =
-        !normalizedBoard || normalize(commentItem.board) === normalizedBoard
-      const matchesSearch =
-        !normalizedSearch ||
-        normalize(commentItem.postTitle).includes(normalizedSearch) ||
-        normalize(commentItem.content).includes(normalizedSearch)
-
-      return matchesBoard && matchesSearch
+    const b = normalize(selectedBoard)
+    const s = normalize(search)
+    return comments.filter((c) => {
+      const okBoard = !b || normalize(c.board) === b
+      const okSearch =
+        !s ||
+        normalize(c.postTitle).includes(s) ||
+        normalize(c.content).includes(s)
+      return okBoard && okSearch
     })
   }, [comments, selectedBoard, search])
 
@@ -270,17 +374,15 @@ export function useMyPageController() {
 
     const message =
       error instanceof Error ? error.message : error ? String(error) : ''
-    const errorKey = `${tab}:${message}`
+    const key = `${tab}:${message}`
+    if (lastErrorKeyRef.current === key) return
+    lastErrorKeyRef.current = key
 
-    if (lastErrorKeyRef.current === errorKey) return
-    lastErrorKeyRef.current = errorKey
-
-    if (message) {
-      console.error('[MyPage] query error:', error)
-      toast.error(`마이페이지 데이터를 불러오지 못했습니다. (${message})`)
-    } else {
-      toast.error('마이페이지 데이터를 불러오지 못했습니다.')
-    }
+    toast.error(
+      message
+        ? `마이페이지 데이터를 불러오지 못했습니다. (${message})`
+        : '마이페이지 데이터를 불러오지 못했습니다.'
+    )
   }, [
     tab,
     myPostsQuery.error,
@@ -316,42 +418,35 @@ export function useMyPageController() {
   }
 
   const handleToggleOne = (identifier: string) => {
-    setCheckedMap((previous) => ({
-      ...previous,
-      [identifier]: !previous[identifier],
-    }))
+    setCheckedMap((prev) => ({ ...prev, [identifier]: !prev[identifier] }))
   }
 
   const actionLabel = tab === 'like' ? '해지하기' : '삭제하기'
 
   const handleClickAction = async () => {
-    const selectedIdentifiers = Object.entries(checkedMap)
-      .filter(([, selected]) => selected)
-      .map(([identifier]) => Number(identifier))
-      .filter((identifier) => Number.isFinite(identifier))
+    const selectedIds = Object.entries(checkedMap)
+      .filter(([, v]) => v)
+      .map(([k]) => Number(k))
+      .filter((n) => Number.isFinite(n))
 
-    const selectedCount = selectedIdentifiers.length
-
-    if (selectedCount === 0) {
+    if (selectedIds.length === 0) {
       toast.error('선택된 항목이 없습니다.')
       return
     }
 
     try {
       if (tab === 'post') {
-        await deleteMyPosts.mutateAsync(selectedIdentifiers)
+        await deleteMyPosts.mutateAsync(selectedIds)
         toast.success('선택한 게시글을 삭제했습니다.')
         setCheckedMap({})
         return
       }
-
       if (tab === 'comment') {
-        await deleteMyComments.mutateAsync(selectedIdentifiers)
+        await deleteMyComments.mutateAsync(selectedIds)
         toast.success('선택한 댓글을 삭제했습니다.')
         setCheckedMap({})
         return
       }
-
       toast.success('좋아요를 해지했습니다.')
       setCheckedMap({})
     } catch {

--- a/src/features/mypage/hook/useMyPageController.ts
+++ b/src/features/mypage/hook/useMyPageController.ts
@@ -1,6 +1,8 @@
 'use client'
 
 import { useMemo, useState, useSyncExternalStore } from 'react'
+import { toast } from 'sonner'
+
 import type { SortOption } from '@/features/mypage/ui/PostFilter'
 
 import { useSessionStore } from '@/entities/session/store/session-store'
@@ -28,7 +30,6 @@ import {
   useMyPageFilteredPosts,
 } from '@/features/mypage/hook/useMyPageFilteredList'
 import { useMyPageErrorToast } from '@/features/mypage/hook/useMyPageErrorToast'
-import { toast } from 'sonner'
 
 type TabType = 'post' | 'comment' | 'like'
 
@@ -53,31 +54,33 @@ export function useMyPageController() {
     () => false
   )
 
-  const user = isClient ? sessionUser : null
+  const isClientEnvironment = isClient
+  const user = isClientEnvironment ? sessionUser : null
 
   const myPostsQuery = useMyPosts(
     { page, size: 10, sort: sortBy },
-    { enabled: isClient && tab === 'post' }
+    { enabled: isClientEnvironment && tab === 'post' }
   )
   const myCommentsQuery = useMyComments(
     { page, size: 15, sort: sortBy },
-    { enabled: isClient && tab === 'comment' }
+    { enabled: isClientEnvironment && tab === 'comment' }
   )
   const likedPostsQuery = useLikedPosts(
     { page, size: 10, sort: sortBy },
-    { enabled: isClient && tab === 'like' }
+    { enabled: isClientEnvironment && tab === 'like' }
   )
 
   const deleteMyPosts = useDeleteMyPosts()
   const deleteMyComments = useDeleteMyComments()
 
-  const { timeline } = useMyPageTimeline(isClient)
+  const { timeline } = useMyPageTimeline(isClientEnvironment)
   const { profile } = useMyPageProfile(user)
 
   const { basePosts } = useMyPageBasePosts({
     user,
     posts: myPostsQuery.data?.posts,
   })
+
   const { baseLikedPosts } = useMyPageBaseLikedPosts({
     user,
     posts: likedPostsQuery.data?.posts,
@@ -85,12 +88,13 @@ export function useMyPageController() {
 
   const { posts } = useMyPagePostsWithDetailThumbnail({
     tab,
-    isClient,
+    isClientEnvironment,
     basePosts,
   })
+
   const { likedPosts } = useMyPageLikedPostsWithDetailThumbnail({
     tab,
-    isClient,
+    isClientEnvironment,
     baseLikedPosts,
   })
 
@@ -101,11 +105,13 @@ export function useMyPageController() {
     selectedBoard,
     search,
   })
+
   const { filteredLikes } = useMyPageFilteredLikes({
     likedPosts,
     selectedBoard,
     search,
   })
+
   const { filteredComments } = useMyPageFilteredComments({
     comments,
     selectedBoard,
@@ -144,35 +150,40 @@ export function useMyPageController() {
   }
 
   const handleToggleOne = (identifier: string) => {
-    setCheckedMap((prev) => ({ ...prev, [identifier]: !prev[identifier] }))
+    setCheckedMap((previousCheckedMap) => ({
+      ...previousCheckedMap,
+      [identifier]: !previousCheckedMap[identifier],
+    }))
   }
 
   const actionLabel = tab === 'like' ? '해지하기' : '삭제하기'
 
   const handleClickAction = async () => {
-    const selectedIds = Object.entries(checkedMap)
-      .filter(([, v]) => v)
-      .map(([k]) => Number(k))
-      .filter((n) => Number.isFinite(n))
+    const selectedIdNumbers = Object.entries(checkedMap)
+      .filter(([, isSelected]) => isSelected)
+      .map(([identifier]) => Number(identifier))
+      .filter((selectedIdNumber) => Number.isFinite(selectedIdNumber))
 
-    if (selectedIds.length === 0) {
+    if (selectedIdNumbers.length === 0) {
       toast.error('선택된 항목이 없습니다.')
       return
     }
 
     try {
       if (tab === 'post') {
-        await deleteMyPosts.mutateAsync(selectedIds)
+        await deleteMyPosts.mutateAsync(selectedIdNumbers)
         toast.success('선택한 게시글을 삭제했습니다.')
         setCheckedMap({})
         return
       }
+
       if (tab === 'comment') {
-        await deleteMyComments.mutateAsync(selectedIds)
+        await deleteMyComments.mutateAsync(selectedIdNumbers)
         toast.success('선택한 댓글을 삭제했습니다.')
         setCheckedMap({})
         return
       }
+
       toast.success('좋아요를 해지했습니다.')
       setCheckedMap({})
     } catch {
@@ -181,10 +192,18 @@ export function useMyPageController() {
   }
 
   const totalPages = useMemo(() => {
-    if (tab === 'post') return myPostsQuery.data?.pagination.totalPages ?? 1
-    if (tab === 'comment')
+    if (tab === 'post') {
+      return myPostsQuery.data?.pagination.totalPages ?? 1
+    }
+
+    if (tab === 'comment') {
       return myCommentsQuery.data?.pagination.totalPages ?? 1
-    if (tab === 'like') return likedPostsQuery.data?.pagination.totalPages ?? 1
+    }
+
+    if (tab === 'like') {
+      return likedPostsQuery.data?.pagination.totalPages ?? 1
+    }
+
     return 1
   }, [
     tab,
@@ -194,7 +213,7 @@ export function useMyPageController() {
   ])
 
   const isCurrentTabLoading =
-    !isClient ||
+    !isClientEnvironment ||
     (tab === 'post' && myPostsQuery.isLoading) ||
     (tab === 'comment' && myCommentsQuery.isLoading) ||
     (tab === 'like' && likedPostsQuery.isLoading)
@@ -210,9 +229,11 @@ export function useMyPageController() {
     user,
     profile,
     timeline,
+
     filteredPosts,
     filteredComments,
     filteredLikes,
+
     totalPages,
     actionLabel,
     isCurrentTabLoading,

--- a/src/features/mypage/hook/useMyPageController.ts
+++ b/src/features/mypage/hook/useMyPageController.ts
@@ -1,0 +1,407 @@
+'use client'
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
+import { toast } from 'sonner'
+
+import type { SortOption } from '@/features/mypage/ui/PostFilter'
+import type {
+  MyCommentItem,
+  MyPagePostItem,
+} from '@/entities/mypage/model/mypage-ui-types'
+
+import { useSessionStore } from '@/entities/session/store/session-store'
+
+import { useMyPosts } from '@/features/mypage/hook/useMyPost'
+import { useMyComments } from '@/features/mypage/hook/useMyComments'
+import { useLikedPosts } from '@/features/mypage/hook/useLikes'
+import { useDeleteMyPosts } from '@/features/mypage/hook/useDeleteMyPost'
+import { useDeleteMyComments } from '@/features/mypage/hook/useDeleteMyComments'
+import { useTimelineHistory } from '@/features/mypage/hook/useTimeline'
+
+import { normalize } from '@/features/mypage/lib/text'
+import {
+  addDays,
+  formatDateParts,
+  startOfKoreaStandardTimeDay,
+  toKoreanDay,
+  toMonthDay,
+  toYearMonthDay,
+} from '@/features/mypage/lib/data-kst'
+
+import type { TimelineItem } from '@/features/mypage/ui/TimeLine'
+
+type TabType = 'post' | 'comment' | 'like'
+
+const DEFAULT_THUMBNAIL = '/images/mypage/post-example.png'
+const DEFAULT_AVATAR = '/images/profiles/default-1.webp'
+
+export function useMyPageController() {
+  const [tab, setTab] = useState<TabType>('post')
+  const [page, setPage] = useState(1)
+
+  const [selectedBoard, setSelectedBoard] = useState('')
+  const [search, setSearch] = useState('')
+
+  const [sortBy, setSortBy] = useState<SortOption>('latest')
+  const [checkedMap, setCheckedMap] = useState<Record<string, boolean>>({})
+
+  const sessionUser = useSessionStore((state) => state.user)
+
+  // 기존 동작 유지: SSR 시점에는 user=null 유지
+  const isClient = useSyncExternalStore(
+    (onStoreChange) => {
+      queueMicrotask(onStoreChange)
+      return () => {}
+    },
+    () => true,
+    () => false
+  )
+
+  const user = isClient ? sessionUser : null
+
+  const myPostsQuery = useMyPosts(
+    { page, size: 10, sort: sortBy },
+    { enabled: isClient && tab === 'post' }
+  )
+  const myCommentsQuery = useMyComments(
+    { page, size: 15, sort: sortBy },
+    { enabled: isClient && tab === 'comment' }
+  )
+  const likedPostsQuery = useLikedPosts(
+    { page, size: 10, sort: sortBy },
+    { enabled: isClient && tab === 'like' }
+  )
+
+  const deleteMyPosts = useDeleteMyPosts()
+  const deleteMyComments = useDeleteMyComments()
+
+  const lastErrorKeyRef = useRef<string | null>(null)
+
+  const timelineHistoryQuery = useTimelineHistory(isClient)
+
+  const noHistoryToastOnceRef = useRef(false)
+  useEffect(() => {
+    if (!timelineHistoryQuery.isSuccess) return
+    if (noHistoryToastOnceRef.current) return
+
+    const results = timelineHistoryQuery.data?.results ?? []
+    if (results.length === 0) {
+      noHistoryToastOnceRef.current = true
+      toast('아직 출석 기록이 없습니다')
+    }
+  }, [timelineHistoryQuery.isSuccess, timelineHistoryQuery.data?.results])
+
+  const timeline = useMemo<TimelineItem[]>(() => {
+    const today = startOfKoreaStandardTimeDay()
+    const results = timelineHistoryQuery.data?.results ?? []
+
+    const submittedMap = new Map<string, boolean>()
+    for (const resultItem of results) {
+      submittedMap.set(resultItem.date, !!resultItem.is_submitted)
+    }
+
+    const items: TimelineItem[] = []
+    for (let offsetDays = -3; offsetDays <= 3; offsetDays += 1) {
+      const dateObject = addDays(today, offsetDays)
+      const yearMonthDay = toYearMonthDay(dateObject)
+      const submitted = submittedMap.get(yearMonthDay) ?? false
+
+      let status: TimelineItem['status'] = 'upcoming'
+      if (offsetDays > 0) status = 'upcoming'
+      else if (offsetDays === 0) status = submitted ? 'done' : 'go'
+      else status = submitted ? 'done' : 'fail'
+
+      items.push({
+        date: toMonthDay(dateObject),
+        day: toKoreanDay(dateObject),
+        status,
+      })
+    }
+
+    return items
+  }, [timelineHistoryQuery.data?.results])
+
+  const profile = useMemo(() => {
+    return {
+      nickname: user?.nickname ?? '',
+      email: user?.email ?? '',
+      joinedAt: '-',
+      profileImageSrc: user?.profileImageUrl ?? null,
+      balloonLeft: {
+        title: '오늘도 힘내봐요!',
+        subtitle: 'Hazlo lo mejor que puedas hoy también',
+      },
+      balloonRight: {
+        title: 'STUDY GO !',
+      },
+    }
+  }, [user?.email, user?.nickname, user?.profileImageUrl])
+
+  const posts = useMemo<MyPagePostItem[]>(() => {
+    const author = user?.nickname ?? ''
+    const profileImageUrl = user?.profileImageUrl
+    const safeAvatar = profileImageUrl ?? DEFAULT_AVATAR
+
+    return (myPostsQuery.data?.posts ?? []).map((postItem) => {
+      const { date, time } = formatDateParts(postItem.createdAt)
+      return {
+        id: postItem.id,
+        author,
+        date,
+        time,
+        title: postItem.title,
+        views: 0,
+        likes: 0,
+        comments: 0,
+        avatar: safeAvatar,
+        thumbnail: DEFAULT_THUMBNAIL,
+        board: 'free',
+      }
+    })
+  }, [myPostsQuery.data?.posts, user?.nickname, user?.profileImageUrl])
+
+  const likedPosts = useMemo<MyPagePostItem[]>(() => {
+    const author = user?.nickname ?? ''
+    const profileImageUrl = user?.profileImageUrl
+    const safeAvatar = profileImageUrl ?? DEFAULT_AVATAR
+
+    return (likedPostsQuery.data?.posts ?? []).map((postItem) => {
+      const createdAt = postItem.likedAt ?? postItem.createdAt ?? ''
+      const { date, time } = formatDateParts(createdAt)
+      return {
+        id: postItem.id,
+        author,
+        date,
+        time,
+        title: postItem.title,
+        views: 0,
+        likes: 0,
+        comments: 0,
+        avatar: safeAvatar,
+        thumbnail: DEFAULT_THUMBNAIL,
+        board: 'free',
+      }
+    })
+  }, [likedPostsQuery.data?.posts, user?.nickname, user?.profileImageUrl])
+
+  const comments = useMemo<MyCommentItem[]>(() => {
+    const commentItems = myCommentsQuery.data?.comments ?? []
+    return commentItems.map((commentItem) => {
+      return {
+        commentId: String(commentItem.id),
+        postId: commentItem.postId == null ? null : String(commentItem.postId),
+        postTitle: commentItem.postTitle ?? null,
+        content: commentItem.content ?? null,
+        createdAt: commentItem.createdAt,
+        board: null,
+      }
+    })
+  }, [myCommentsQuery.data?.comments])
+
+  const filteredPosts = useMemo(() => {
+    const normalizedBoard = normalize(selectedBoard)
+    const normalizedSearch = normalize(search)
+
+    return posts.filter((postItem) => {
+      const matchesBoard =
+        !normalizedBoard || normalize(postItem.board) === normalizedBoard
+      const matchesSearch =
+        !normalizedSearch ||
+        normalize(postItem.title).includes(normalizedSearch) ||
+        normalize(postItem.author).includes(normalizedSearch)
+
+      return matchesBoard && matchesSearch
+    })
+  }, [posts, selectedBoard, search])
+
+  const filteredLikes = useMemo(() => {
+    const normalizedBoard = normalize(selectedBoard)
+    const normalizedSearch = normalize(search)
+
+    return likedPosts.filter((postItem) => {
+      const matchesBoard =
+        !normalizedBoard || normalize(postItem.board) === normalizedBoard
+      const matchesSearch =
+        !normalizedSearch ||
+        normalize(postItem.title).includes(normalizedSearch) ||
+        normalize(postItem.author).includes(normalizedSearch)
+
+      return matchesBoard && matchesSearch
+    })
+  }, [likedPosts, selectedBoard, search])
+
+  const filteredComments = useMemo(() => {
+    const normalizedBoard = normalize(selectedBoard)
+    const normalizedSearch = normalize(search)
+
+    return comments.filter((commentItem) => {
+      const matchesBoard =
+        !normalizedBoard || normalize(commentItem.board) === normalizedBoard
+      const matchesSearch =
+        !normalizedSearch ||
+        normalize(commentItem.postTitle).includes(normalizedSearch) ||
+        normalize(commentItem.content).includes(normalizedSearch)
+
+      return matchesBoard && matchesSearch
+    })
+  }, [comments, selectedBoard, search])
+
+  useEffect(() => {
+    const isError =
+      (tab === 'post' && myPostsQuery.isError) ||
+      (tab === 'comment' && myCommentsQuery.isError) ||
+      (tab === 'like' && likedPostsQuery.isError)
+
+    if (!isError) {
+      lastErrorKeyRef.current = null
+      return
+    }
+
+    const error =
+      (tab === 'post' && myPostsQuery.error) ||
+      (tab === 'comment' && myCommentsQuery.error) ||
+      (tab === 'like' && likedPostsQuery.error)
+
+    const message =
+      error instanceof Error ? error.message : error ? String(error) : ''
+    const errorKey = `${tab}:${message}`
+
+    if (lastErrorKeyRef.current === errorKey) return
+    lastErrorKeyRef.current = errorKey
+
+    if (message) {
+      console.error('[MyPage] query error:', error)
+      toast.error(`마이페이지 데이터를 불러오지 못했습니다. (${message})`)
+    } else {
+      toast.error('마이페이지 데이터를 불러오지 못했습니다.')
+    }
+  }, [
+    tab,
+    myPostsQuery.error,
+    myPostsQuery.isError,
+    myCommentsQuery.error,
+    myCommentsQuery.isError,
+    likedPostsQuery.error,
+    likedPostsQuery.isError,
+  ])
+
+  const handleChangeTab = (nextTab: TabType) => {
+    setTab(nextTab)
+    setPage(1)
+    setCheckedMap({})
+  }
+
+  const handleChangeSortBy = (nextSortBy: SortOption) => {
+    setSortBy(nextSortBy)
+    setPage(1)
+    setCheckedMap({})
+  }
+
+  const handleChangeBoard = (nextBoard: string) => {
+    setSelectedBoard(nextBoard)
+    setPage(1)
+    setCheckedMap({})
+  }
+
+  const handleChangeSearch = (nextSearch: string) => {
+    setSearch(nextSearch)
+    setPage(1)
+    setCheckedMap({})
+  }
+
+  const handleToggleOne = (identifier: string) => {
+    setCheckedMap((previous) => ({
+      ...previous,
+      [identifier]: !previous[identifier],
+    }))
+  }
+
+  const actionLabel = tab === 'like' ? '해지하기' : '삭제하기'
+
+  const handleClickAction = async () => {
+    const selectedIdentifiers = Object.entries(checkedMap)
+      .filter(([, selected]) => selected)
+      .map(([identifier]) => Number(identifier))
+      .filter((identifier) => Number.isFinite(identifier))
+
+    const selectedCount = selectedIdentifiers.length
+
+    if (selectedCount === 0) {
+      toast.error('선택된 항목이 없습니다.')
+      return
+    }
+
+    try {
+      if (tab === 'post') {
+        await deleteMyPosts.mutateAsync(selectedIdentifiers)
+        toast.success('선택한 게시글을 삭제했습니다.')
+        setCheckedMap({})
+        return
+      }
+
+      if (tab === 'comment') {
+        await deleteMyComments.mutateAsync(selectedIdentifiers)
+        toast.success('선택한 댓글을 삭제했습니다.')
+        setCheckedMap({})
+        return
+      }
+
+      toast.success('좋아요를 해지했습니다.')
+      setCheckedMap({})
+    } catch {
+      toast.error('요청 처리에 실패했습니다.')
+    }
+  }
+
+  const totalPages = useMemo(() => {
+    if (tab === 'post') return myPostsQuery.data?.pagination.totalPages ?? 1
+    if (tab === 'comment')
+      return myCommentsQuery.data?.pagination.totalPages ?? 1
+    if (tab === 'like') return likedPostsQuery.data?.pagination.totalPages ?? 1
+    return 1
+  }, [
+    tab,
+    myPostsQuery.data?.pagination.totalPages,
+    myCommentsQuery.data?.pagination.totalPages,
+    likedPostsQuery.data?.pagination.totalPages,
+  ])
+
+  const isCurrentTabLoading =
+    !isClient ||
+    (tab === 'post' && myPostsQuery.isLoading) ||
+    (tab === 'comment' && myCommentsQuery.isLoading) ||
+    (tab === 'like' && likedPostsQuery.isLoading)
+
+  return {
+    tab,
+    page,
+    selectedBoard,
+    search,
+    sortBy,
+    checkedMap,
+
+    user,
+    profile,
+    timeline,
+    filteredPosts,
+    filteredComments,
+    filteredLikes,
+    totalPages,
+    actionLabel,
+    isCurrentTabLoading,
+
+    setPage,
+    handleChangeTab,
+    handleChangeBoard,
+    handleChangeSearch,
+    handleChangeSortBy,
+    handleToggleOne,
+    handleClickAction,
+  }
+}

--- a/src/features/mypage/hook/useMyPageDetailThumbnailMerge.ts
+++ b/src/features/mypage/hook/useMyPageDetailThumbnailMerge.ts
@@ -5,92 +5,140 @@ import type { MyPagePostItem } from '@/entities/mypage/model/mypage-ui-types'
 import { getPostDetailApi } from '@/entities/mypage/api/post-detail-api'
 import { pickDetailThumbnail } from '@/features/mypage/lib/mypage-content-picker'
 
+type TabType = 'post' | 'comment' | 'like'
+
 export function useMyPagePostsWithDetailThumbnail(params: {
-  tab: 'post' | 'comment' | 'like'
-  isClient: boolean
+  tab: TabType
+  isClientEnvironment: boolean
   basePosts: MyPagePostItem[]
 }) {
-  const { tab, isClient, basePosts } = params
+  const { tab, isClientEnvironment, basePosts } = params
 
-  const needDetailPostIds = useMemo(() => {
-    if (tab !== 'post') return []
+  const postIdentifiersNeedingDetailThumbnail = useMemo(() => {
+    if (tab !== 'post') {
+      return []
+    }
+
     return basePosts
-      .filter((p) => !p.thumbnail)
-      .map((p) => p.id)
+      .filter((postItem) => !postItem.thumbnail)
+      .map((postItem) => postItem.id)
       .slice(0, 10)
   }, [tab, basePosts])
 
   const postDetailQueries = useQueries({
-    queries: needDetailPostIds.map((id) => ({
-      queryKey: ['post-detail', id],
-      queryFn: () => getPostDetailApi(id),
-      enabled: isClient && tab === 'post',
+    queries: postIdentifiersNeedingDetailThumbnail.map((postIdentifier) => ({
+      queryKey: ['post-detail', postIdentifier],
+      queryFn: () => getPostDetailApi(postIdentifier),
+      enabled: isClientEnvironment && tab === 'post',
       staleTime: 1000 * 60 * 10,
     })),
   })
 
-  const posts = useMemo<MyPagePostItem[]>(() => {
-    if (tab !== 'post') return basePosts
-
-    const map = new Map<number, string>()
-    for (let i = 0; i < needDetailPostIds.length; i += 1) {
-      const id = needDetailPostIds[i]
-      const detail = postDetailQueries[i]?.data
-      if (!detail) continue
-      const thumb = pickDetailThumbnail(detail)
-      if (thumb) map.set(id, thumb)
+  const postsWithMergedThumbnails = useMemo<MyPagePostItem[]>(() => {
+    if (tab !== 'post') {
+      return basePosts
     }
 
-    return basePosts.map((p) => ({
-      ...p,
-      thumbnail: p.thumbnail || map.get(p.id) || '',
-    }))
-  }, [tab, basePosts, needDetailPostIds, postDetailQueries])
+    const thumbnailUrlByPostIdentifierMap = new Map<number, string>()
 
-  return { posts }
+    for (
+      let queryIndex = 0;
+      queryIndex < postIdentifiersNeedingDetailThumbnail.length;
+      queryIndex += 1
+    ) {
+      const postIdentifier = postIdentifiersNeedingDetailThumbnail[queryIndex]
+      const postDetailData = postDetailQueries[queryIndex]?.data
+
+      if (!postDetailData) {
+        continue
+      }
+
+      const thumbnailUrl = pickDetailThumbnail(postDetailData)
+      if (thumbnailUrl) {
+        thumbnailUrlByPostIdentifierMap.set(postIdentifier, thumbnailUrl)
+      }
+    }
+
+    return basePosts.map((postItem) => ({
+      ...postItem,
+      thumbnail:
+        postItem.thumbnail ||
+        thumbnailUrlByPostIdentifierMap.get(postItem.id) ||
+        '',
+    }))
+  }, [tab, basePosts, postIdentifiersNeedingDetailThumbnail, postDetailQueries])
+
+  return { posts: postsWithMergedThumbnails }
 }
 
 export function useMyPageLikedPostsWithDetailThumbnail(params: {
-  tab: 'post' | 'comment' | 'like'
-  isClient: boolean
+  tab: TabType
+  isClientEnvironment: boolean
   baseLikedPosts: MyPagePostItem[]
 }) {
-  const { tab, isClient, baseLikedPosts } = params
+  const { tab, isClientEnvironment, baseLikedPosts } = params
 
-  const needDetailLikeIds = useMemo(() => {
-    if (tab !== 'like') return []
+  const likedPostIdentifiersNeedingDetailThumbnail = useMemo(() => {
+    if (tab !== 'like') {
+      return []
+    }
+
     return baseLikedPosts
-      .filter((p) => !p.thumbnail)
-      .map((p) => p.id)
+      .filter((postItem) => !postItem.thumbnail)
+      .map((postItem) => postItem.id)
       .slice(0, 10)
   }, [tab, baseLikedPosts])
 
-  const likeDetailQueries = useQueries({
-    queries: needDetailLikeIds.map((id) => ({
-      queryKey: ['post-detail', id],
-      queryFn: () => getPostDetailApi(id),
-      enabled: isClient && tab === 'like',
-      staleTime: 1000 * 60 * 10,
-    })),
+  const likedPostDetailQueries = useQueries({
+    queries: likedPostIdentifiersNeedingDetailThumbnail.map(
+      (postIdentifier) => ({
+        queryKey: ['post-detail', postIdentifier],
+        queryFn: () => getPostDetailApi(postIdentifier),
+        enabled: isClientEnvironment && tab === 'like',
+        staleTime: 1000 * 60 * 10,
+      })
+    ),
   })
 
-  const likedPosts = useMemo<MyPagePostItem[]>(() => {
-    if (tab !== 'like') return baseLikedPosts
-
-    const map = new Map<number, string>()
-    for (let i = 0; i < needDetailLikeIds.length; i += 1) {
-      const id = needDetailLikeIds[i]
-      const detail = likeDetailQueries[i]?.data
-      if (!detail) continue
-      const thumb = pickDetailThumbnail(detail)
-      if (thumb) map.set(id, thumb)
+  const likedPostsWithMergedThumbnails = useMemo<MyPagePostItem[]>(() => {
+    if (tab !== 'like') {
+      return baseLikedPosts
     }
 
-    return baseLikedPosts.map((p) => ({
-      ...p,
-      thumbnail: p.thumbnail || map.get(p.id) || '',
-    }))
-  }, [tab, baseLikedPosts, needDetailLikeIds, likeDetailQueries])
+    const thumbnailUrlByPostIdentifierMap = new Map<number, string>()
 
-  return { likedPosts }
+    for (
+      let queryIndex = 0;
+      queryIndex < likedPostIdentifiersNeedingDetailThumbnail.length;
+      queryIndex += 1
+    ) {
+      const postIdentifier =
+        likedPostIdentifiersNeedingDetailThumbnail[queryIndex]
+      const postDetailData = likedPostDetailQueries[queryIndex]?.data
+
+      if (!postDetailData) {
+        continue
+      }
+
+      const thumbnailUrl = pickDetailThumbnail(postDetailData)
+      if (thumbnailUrl) {
+        thumbnailUrlByPostIdentifierMap.set(postIdentifier, thumbnailUrl)
+      }
+    }
+
+    return baseLikedPosts.map((postItem) => ({
+      ...postItem,
+      thumbnail:
+        postItem.thumbnail ||
+        thumbnailUrlByPostIdentifierMap.get(postItem.id) ||
+        '',
+    }))
+  }, [
+    tab,
+    baseLikedPosts,
+    likedPostIdentifiersNeedingDetailThumbnail,
+    likedPostDetailQueries,
+  ])
+
+  return { likedPosts: likedPostsWithMergedThumbnails }
 }

--- a/src/features/mypage/hook/useMyPageDetailThumbnailMerge.ts
+++ b/src/features/mypage/hook/useMyPageDetailThumbnailMerge.ts
@@ -1,0 +1,96 @@
+import { useMemo } from 'react'
+import { useQueries } from '@tanstack/react-query'
+
+import type { MyPagePostItem } from '@/entities/mypage/model/mypage-ui-types'
+import { getPostDetailApi } from '@/entities/mypage/api/post-detail-api'
+import { pickDetailThumbnail } from '@/features/mypage/lib/mypage-content-picker'
+
+export function useMyPagePostsWithDetailThumbnail(params: {
+  tab: 'post' | 'comment' | 'like'
+  isClient: boolean
+  basePosts: MyPagePostItem[]
+}) {
+  const { tab, isClient, basePosts } = params
+
+  const needDetailPostIds = useMemo(() => {
+    if (tab !== 'post') return []
+    return basePosts
+      .filter((p) => !p.thumbnail)
+      .map((p) => p.id)
+      .slice(0, 10)
+  }, [tab, basePosts])
+
+  const postDetailQueries = useQueries({
+    queries: needDetailPostIds.map((id) => ({
+      queryKey: ['post-detail', id],
+      queryFn: () => getPostDetailApi(id),
+      enabled: isClient && tab === 'post',
+      staleTime: 1000 * 60 * 10,
+    })),
+  })
+
+  const posts = useMemo<MyPagePostItem[]>(() => {
+    if (tab !== 'post') return basePosts
+
+    const map = new Map<number, string>()
+    for (let i = 0; i < needDetailPostIds.length; i += 1) {
+      const id = needDetailPostIds[i]
+      const detail = postDetailQueries[i]?.data
+      if (!detail) continue
+      const thumb = pickDetailThumbnail(detail)
+      if (thumb) map.set(id, thumb)
+    }
+
+    return basePosts.map((p) => ({
+      ...p,
+      thumbnail: p.thumbnail || map.get(p.id) || '',
+    }))
+  }, [tab, basePosts, needDetailPostIds, postDetailQueries])
+
+  return { posts }
+}
+
+export function useMyPageLikedPostsWithDetailThumbnail(params: {
+  tab: 'post' | 'comment' | 'like'
+  isClient: boolean
+  baseLikedPosts: MyPagePostItem[]
+}) {
+  const { tab, isClient, baseLikedPosts } = params
+
+  const needDetailLikeIds = useMemo(() => {
+    if (tab !== 'like') return []
+    return baseLikedPosts
+      .filter((p) => !p.thumbnail)
+      .map((p) => p.id)
+      .slice(0, 10)
+  }, [tab, baseLikedPosts])
+
+  const likeDetailQueries = useQueries({
+    queries: needDetailLikeIds.map((id) => ({
+      queryKey: ['post-detail', id],
+      queryFn: () => getPostDetailApi(id),
+      enabled: isClient && tab === 'like',
+      staleTime: 1000 * 60 * 10,
+    })),
+  })
+
+  const likedPosts = useMemo<MyPagePostItem[]>(() => {
+    if (tab !== 'like') return baseLikedPosts
+
+    const map = new Map<number, string>()
+    for (let i = 0; i < needDetailLikeIds.length; i += 1) {
+      const id = needDetailLikeIds[i]
+      const detail = likeDetailQueries[i]?.data
+      if (!detail) continue
+      const thumb = pickDetailThumbnail(detail)
+      if (thumb) map.set(id, thumb)
+    }
+
+    return baseLikedPosts.map((p) => ({
+      ...p,
+      thumbnail: p.thumbnail || map.get(p.id) || '',
+    }))
+  }, [tab, baseLikedPosts, needDetailLikeIds, likeDetailQueries])
+
+  return { likedPosts }
+}

--- a/src/features/mypage/hook/useMyPageErrorToast.ts
+++ b/src/features/mypage/hook/useMyPageErrorToast.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+import type { UseQueryResult } from '@tanstack/react-query'
+
+type TabType = 'post' | 'comment' | 'like'
+
+type QueryLike = Pick<UseQueryResult<unknown, unknown>, 'isError' | 'error'>
+
+export function useMyPageErrorToast(params: {
+  tab: TabType
+  myPostsQuery: QueryLike
+  myCommentsQuery: QueryLike
+  likedPostsQuery: QueryLike
+}) {
+  const { tab, myPostsQuery, myCommentsQuery, likedPostsQuery } = params
+
+  const lastErrorKeyRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const isError =
+      (tab === 'post' && myPostsQuery.isError) ||
+      (tab === 'comment' && myCommentsQuery.isError) ||
+      (tab === 'like' && likedPostsQuery.isError)
+
+    if (!isError) {
+      lastErrorKeyRef.current = null
+      return
+    }
+
+    const error =
+      (tab === 'post' && myPostsQuery.error) ||
+      (tab === 'comment' && myCommentsQuery.error) ||
+      (tab === 'like' && likedPostsQuery.error)
+
+    const message =
+      error instanceof Error ? error.message : error ? String(error) : ''
+
+    const errorKey = `${tab}:${message}`
+
+    if (lastErrorKeyRef.current === errorKey) {
+      return
+    }
+
+    lastErrorKeyRef.current = errorKey
+
+    toast.error(
+      message
+        ? `마이페이지 데이터를 불러오지 못했습니다. (${message})`
+        : '마이페이지 데이터를 불러오지 못했습니다.'
+    )
+  }, [
+    tab,
+    myPostsQuery.error,
+    myPostsQuery.isError,
+    myCommentsQuery.error,
+    myCommentsQuery.isError,
+    likedPostsQuery.error,
+    likedPostsQuery.isError,
+  ])
+}

--- a/src/features/mypage/hook/useMyPageFilteredList.ts
+++ b/src/features/mypage/hook/useMyPageFilteredList.ts
@@ -1,0 +1,90 @@
+import { useMemo } from 'react'
+import type {
+  MyCommentItem,
+  MyPagePostItem,
+} from '@/entities/mypage/model/mypage-ui-types'
+import { normalize } from '@/features/mypage/lib/text'
+
+export function useMyPageFilteredPosts(params: {
+  posts: MyPagePostItem[]
+  selectedBoard: string
+  search: string
+}) {
+  const { posts, selectedBoard, search } = params
+
+  const filteredPosts = useMemo(() => {
+    const normalizedSelectedBoard = normalize(selectedBoard)
+    const normalizedSearchText = normalize(search)
+
+    return posts.filter((postItem) => {
+      const boardMatches =
+        normalizedSelectedBoard === '' ||
+        normalize(postItem.board) === normalizedSelectedBoard
+
+      const searchMatches =
+        normalizedSearchText === '' ||
+        normalize(postItem.title).includes(normalizedSearchText) ||
+        normalize(postItem.author).includes(normalizedSearchText)
+
+      return boardMatches && searchMatches
+    })
+  }, [posts, selectedBoard, search])
+
+  return { filteredPosts }
+}
+
+export function useMyPageFilteredLikes(params: {
+  likedPosts: MyPagePostItem[]
+  selectedBoard: string
+  search: string
+}) {
+  const { likedPosts, selectedBoard, search } = params
+
+  const filteredLikes = useMemo(() => {
+    const normalizedSelectedBoard = normalize(selectedBoard)
+    const normalizedSearchText = normalize(search)
+
+    return likedPosts.filter((postItem) => {
+      const boardMatches =
+        normalizedSelectedBoard === '' ||
+        normalize(postItem.board) === normalizedSelectedBoard
+
+      const searchMatches =
+        normalizedSearchText === '' ||
+        normalize(postItem.title).includes(normalizedSearchText) ||
+        normalize(postItem.author).includes(normalizedSearchText)
+
+      return boardMatches && searchMatches
+    })
+  }, [likedPosts, selectedBoard, search])
+
+  return { filteredLikes }
+}
+
+export function useMyPageFilteredComments(params: {
+  comments: MyCommentItem[]
+  selectedBoard: string
+  search: string
+}) {
+  const { comments, selectedBoard, search } = params
+
+  const filteredComments = useMemo(() => {
+    const normalizedSelectedBoard = normalize(selectedBoard)
+    const normalizedSearchText = normalize(search)
+
+    return comments.filter((commentItem) => {
+      const boardMatches =
+        normalizedSelectedBoard === '' ||
+        normalize(commentItem.board) === normalizedSelectedBoard
+
+      const searchMatches =
+        normalizedSearchText === '' ||
+        normalize(commentItem.postTitle).includes(normalizedSearchText) ||
+        normalize(commentItem.content).includes(normalizedSearchText)
+
+      return boardMatches && searchMatches
+    })
+  }, [comments, selectedBoard, search])
+
+  return { filteredComments }
+}

--- a/src/features/mypage/hook/useMyPageProfile.ts
+++ b/src/features/mypage/hook/useMyPageProfile.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react'
+
+type UserLike = {
+  nickname?: string | null
+  email?: string | null
+  profileImageUrl?: string | null
+} | null
+
+export function useMyPageProfile(user: UserLike) {
+  const profile = useMemo(() => {
+    return {
+      nickname: user?.nickname ?? '',
+      email: user?.email ?? '',
+      joinedAt: '-',
+      profileImageSrc: user?.profileImageUrl ?? null,
+      balloonLeft: {
+        title: '오늘도 힘내봐요!',
+        subtitle: 'Hazlo lo mejor que puedas hoy también',
+      },
+      balloonRight: { title: 'STUDY GO !' },
+    }
+  }, [user?.email, user?.nickname, user?.profileImageUrl])
+
+  return { profile }
+}

--- a/src/features/mypage/hook/useMyPageTimeline.ts
+++ b/src/features/mypage/hook/useMyPageTimeline.ts
@@ -11,47 +11,63 @@ import {
 } from '@/features/mypage/lib/data-kst'
 import type { TimelineItem } from '@/features/mypage/ui/TimeLine'
 
-export function useMyPageTimeline(isClient: boolean) {
-  const timelineHistoryQuery = useTimelineHistory(isClient)
+export function useMyPageTimeline(isClientEnvironment: boolean) {
+  const timelineHistoryQuery = useTimelineHistory(isClientEnvironment)
 
-  const noHistoryToastOnceRef = useRef(false)
+  const hasShownNoHistoryToastRef = useRef(false)
+
   useEffect(() => {
-    if (!timelineHistoryQuery.isSuccess) return
-    if (noHistoryToastOnceRef.current) return
+    if (!timelineHistoryQuery.isSuccess) {
+      return
+    }
 
-    const results = timelineHistoryQuery.data?.results ?? []
-    if (results.length === 0) {
-      noHistoryToastOnceRef.current = true
+    if (hasShownNoHistoryToastRef.current) {
+      return
+    }
+
+    const historyResults = timelineHistoryQuery.data?.results ?? []
+
+    if (historyResults.length === 0) {
+      hasShownNoHistoryToastRef.current = true
       toast('아직 출석 기록이 없습니다')
     }
   }, [timelineHistoryQuery.isSuccess, timelineHistoryQuery.data?.results])
 
-  const timeline = useMemo<TimelineItem[]>(() => {
-    const today = startOfKoreaStandardTimeDay()
-    const results = timelineHistoryQuery.data?.results ?? []
+  const timelineItems = useMemo<TimelineItem[]>(() => {
+    const todayDate = startOfKoreaStandardTimeDay()
+    const historyResults = timelineHistoryQuery.data?.results ?? []
 
-    const submittedMap = new Map<string, boolean>()
-    for (const r of results) submittedMap.set(r.date, !!r.is_submitted)
+    const submittedDateMap = new Map<string, boolean>()
+    for (const historyItem of historyResults) {
+      submittedDateMap.set(historyItem.date, Boolean(historyItem.is_submitted))
+    }
 
     const items: TimelineItem[] = []
-    for (let d = -3; d <= 3; d += 1) {
-      const dateObject = addDays(today, d)
-      const ymd = toYearMonthDay(dateObject)
-      const submitted = submittedMap.get(ymd) ?? false
+
+    for (let dayOffset = -3; dayOffset <= 3; dayOffset += 1) {
+      const currentDate = addDays(todayDate, dayOffset)
+      const yearMonthDay = toYearMonthDay(currentDate)
+      const isSubmitted = submittedDateMap.get(yearMonthDay) ?? false
 
       let status: TimelineItem['status'] = 'upcoming'
-      if (d > 0) status = 'upcoming'
-      else if (d === 0) status = submitted ? 'done' : 'go'
-      else status = submitted ? 'done' : 'fail'
+
+      if (dayOffset > 0) {
+        status = 'upcoming'
+      } else if (dayOffset === 0) {
+        status = isSubmitted ? 'done' : 'go'
+      } else {
+        status = isSubmitted ? 'done' : 'fail'
+      }
 
       items.push({
-        date: toMonthDay(dateObject),
-        day: toKoreanDay(dateObject),
+        date: toMonthDay(currentDate),
+        day: toKoreanDay(currentDate),
         status,
       })
     }
+
     return items
   }, [timelineHistoryQuery.data?.results])
 
-  return { timeline }
+  return { timeline: timelineItems }
 }

--- a/src/features/mypage/hook/useMyPageTimeline.ts
+++ b/src/features/mypage/hook/useMyPageTimeline.ts
@@ -1,0 +1,57 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { toast } from 'sonner'
+
+import { useTimelineHistory } from '@/features/mypage/hook/useTimeline'
+import {
+  addDays,
+  startOfKoreaStandardTimeDay,
+  toKoreanDay,
+  toMonthDay,
+  toYearMonthDay,
+} from '@/features/mypage/lib/data-kst'
+import type { TimelineItem } from '@/features/mypage/ui/TimeLine'
+
+export function useMyPageTimeline(isClient: boolean) {
+  const timelineHistoryQuery = useTimelineHistory(isClient)
+
+  const noHistoryToastOnceRef = useRef(false)
+  useEffect(() => {
+    if (!timelineHistoryQuery.isSuccess) return
+    if (noHistoryToastOnceRef.current) return
+
+    const results = timelineHistoryQuery.data?.results ?? []
+    if (results.length === 0) {
+      noHistoryToastOnceRef.current = true
+      toast('아직 출석 기록이 없습니다')
+    }
+  }, [timelineHistoryQuery.isSuccess, timelineHistoryQuery.data?.results])
+
+  const timeline = useMemo<TimelineItem[]>(() => {
+    const today = startOfKoreaStandardTimeDay()
+    const results = timelineHistoryQuery.data?.results ?? []
+
+    const submittedMap = new Map<string, boolean>()
+    for (const r of results) submittedMap.set(r.date, !!r.is_submitted)
+
+    const items: TimelineItem[] = []
+    for (let d = -3; d <= 3; d += 1) {
+      const dateObject = addDays(today, d)
+      const ymd = toYearMonthDay(dateObject)
+      const submitted = submittedMap.get(ymd) ?? false
+
+      let status: TimelineItem['status'] = 'upcoming'
+      if (d > 0) status = 'upcoming'
+      else if (d === 0) status = submitted ? 'done' : 'go'
+      else status = submitted ? 'done' : 'fail'
+
+      items.push({
+        date: toMonthDay(dateObject),
+        day: toKoreanDay(dateObject),
+        status,
+      })
+    }
+    return items
+  }, [timelineHistoryQuery.data?.results])
+
+  return { timeline }
+}

--- a/src/features/mypage/lib/data-kst.ts
+++ b/src/features/mypage/lib/data-kst.ts
@@ -1,0 +1,55 @@
+export const formatDateParts = (
+  input: string
+): { date: string; time: string } => {
+  const dateObject = new Date(input)
+  if (Number.isNaN(dateObject.getTime())) return { date: '', time: '' }
+
+  const year = dateObject.getFullYear()
+  const month = String(dateObject.getMonth() + 1).padStart(2, '0')
+  const day = String(dateObject.getDate()).padStart(2, '0')
+  const hour = String(dateObject.getHours()).padStart(2, '0')
+  const minute = String(dateObject.getMinutes()).padStart(2, '0')
+
+  return { date: `${year}.${month}.${day}`, time: `${hour}:${minute}` }
+}
+
+export const getKoreaStandardTimeNow = () => {
+  const now = new Date()
+  const localOffsetMilliseconds = now.getTimezoneOffset() * 60_000
+  const coordinatedUniversalTimeMilliseconds =
+    now.getTime() + localOffsetMilliseconds
+  const koreaStandardTimeMilliseconds =
+    coordinatedUniversalTimeMilliseconds + 9 * 60 * 60_000
+
+  return new Date(koreaStandardTimeMilliseconds)
+}
+
+export const startOfKoreaStandardTimeDay = () => {
+  const dateObject = getKoreaStandardTimeNow()
+  dateObject.setHours(0, 0, 0, 0)
+  return dateObject
+}
+
+export const addDays = (baseDate: Date, offsetDays: number) => {
+  const dateObject = new Date(baseDate)
+  dateObject.setDate(baseDate.getDate() + offsetDays)
+  return dateObject
+}
+
+export const toYearMonthDay = (dateObject: Date) => {
+  const year = dateObject.getFullYear()
+  const month = String(dateObject.getMonth() + 1).padStart(2, '0')
+  const day = String(dateObject.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export const toMonthDay = (dateObject: Date) => {
+  const month = String(dateObject.getMonth() + 1).padStart(2, '0')
+  const day = String(dateObject.getDate()).padStart(2, '0')
+  return `${month}.${day}`
+}
+
+export const toKoreanDay = (dateObject: Date) => {
+  const days = ['일', '월', '화', '수', '목', '금', '토'] as const
+  return days[dateObject.getDay()]
+}

--- a/src/features/mypage/lib/extract-first-image-url.ts
+++ b/src/features/mypage/lib/extract-first-image-url.ts
@@ -1,0 +1,60 @@
+function findImgSrcFromHtml(html: string): string {
+  const match = html.match(/<img[^>]+src=["']([^"']+)["']/i)
+  return match?.[1] ?? ''
+}
+
+function findImgSrcFromMarkdown(md: string): string {
+  const match = md.match(/!\[[^\]]*\]\(([^)]+)\)/)
+  return match?.[1] ?? ''
+}
+
+function walkJson(node: unknown): string {
+  if (!node || typeof node !== 'object') return ''
+
+  const n = node as Record<string, unknown>
+
+  const type = n.type
+  if (typeof type === 'string' && type.toLowerCase().includes('image')) {
+    const attrs = n.attrs
+    if (attrs && typeof attrs === 'object') {
+      const a = attrs as Record<string, unknown>
+      const candidate =
+        a.src ?? a.url ?? a.imageUrl ?? a.href ?? a.originalSrc ?? ''
+      return typeof candidate === 'string' ? candidate : ''
+    }
+    return ''
+  }
+
+  const content = n.content
+  if (Array.isArray(content)) {
+    for (const child of content) {
+      const found = walkJson(child)
+      if (found) return found
+    }
+  }
+
+  return ''
+}
+
+export function extractFirstImageUrl(contentPreview: unknown): string {
+  if (typeof contentPreview !== 'string') return ''
+  const raw = contentPreview.trim()
+  if (!raw) return ''
+
+  if (raw.includes('<img')) {
+    const src = findImgSrcFromHtml(raw)
+    if (src) return src
+  }
+
+  if (raw.includes('![') && raw.includes('](')) {
+    const src = findImgSrcFromMarkdown(raw)
+    if (src) return src
+  }
+
+  try {
+    const doc = JSON.parse(raw)
+    return walkJson(doc)
+  } catch {
+    return ''
+  }
+}

--- a/src/features/mypage/lib/mypage-content-picker.ts
+++ b/src/features/mypage/lib/mypage-content-picker.ts
@@ -1,0 +1,56 @@
+import { extractFirstImageUrl } from '@/features/mypage/lib/extract-first-image-url'
+
+export const DEFAULT_AVATAR = '/images/profiles/default-1.webp'
+
+function pickString(obj: unknown, key: string): string | undefined {
+  if (!obj || typeof obj !== 'object') return undefined
+  const rec = obj as Record<string, unknown>
+  const value = rec[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+function pickFirstString(obj: unknown, keys: string[]): string {
+  for (const k of keys) {
+    const v = pickString(obj, k)
+    if (v) return v
+  }
+  return ''
+}
+
+export function pickContentPreview(obj: unknown): string {
+  return pickFirstString(obj, ['contentPreview', 'content_preview'])
+}
+
+function pickDetailContent(detail: unknown): string {
+  return pickFirstString(detail, [
+    'content',
+    'content_preview',
+    'contentPreview',
+  ])
+}
+
+export function pickDetailThumbnail(detail: unknown): string {
+  if (!detail || typeof detail !== 'object') return ''
+  const rec = detail as Record<string, unknown>
+
+  const thumb = rec['thumbnail_url']
+  if (typeof thumb === 'string' && thumb.trim()) return thumb
+
+  const images = rec['images']
+  if (Array.isArray(images) && images.length > 0) {
+    const first = images[0]
+    if (typeof first === 'string' && first.trim()) return first
+    if (first && typeof first === 'object') {
+      const f = first as Record<string, unknown>
+      const url =
+        (typeof f['url'] === 'string' && f['url']) ||
+        (typeof f['src'] === 'string' && f['src']) ||
+        (typeof f['image_url'] === 'string' && f['image_url']) ||
+        ''
+      if (url) return url
+    }
+  }
+
+  const content = pickDetailContent(detail)
+  return extractFirstImageUrl(content)
+}

--- a/src/features/mypage/lib/text.ts
+++ b/src/features/mypage/lib/text.ts
@@ -1,0 +1,4 @@
+export const normalize = (value: unknown) =>
+  String(value ?? '')
+    .trim()
+    .toLowerCase()

--- a/src/features/mypage/ui/MyComment.tsx
+++ b/src/features/mypage/ui/MyComment.tsx
@@ -69,11 +69,11 @@ const MyComment = ({
   return (
     <div className="divide-brand-gray-100 border-brand-gray-100 divide-y border-t">
       {sorted.map((item) => {
-        const isDeleted = item.postId === null || item.postTitle === null
+        const isDeleted = item.postId === null
 
         const titleText = isDeleted
           ? '삭제된 게시글 입니다'
-          : truncate100(item.postTitle)
+          : truncate100(item.postTitle ?? '제목 없음')
 
         const commentText = truncate100(item.content)
 

--- a/src/features/mypage/ui/MyLike.tsx
+++ b/src/features/mypage/ui/MyLike.tsx
@@ -22,6 +22,22 @@ const getPostTimeMs = (post: MyPagePostItem): number => {
   return Number.isNaN(timestamp) ? 0 : timestamp
 }
 
+const normalizeThumbUrl = (raw: string): string => {
+  const url = raw.trim()
+  if (!url) return ''
+
+  if (
+    url.includes('placehold.co') &&
+    !/\.(png|jpe?g|webp|gif)(\?|$)/i.test(url)
+  ) {
+    return url.replace(/placehold\.co\/(\d+x\d+)(?!\/)/i, 'placehold.co/$1/png')
+  }
+
+  return url
+}
+
+const isSvgUrl = (url: string): boolean => /\.svg(\?|$)/i.test(url)
+
 const MyLike = ({ items, sortBy, checkedMap, onToggleOne }: MyLikeProps) => {
   const router = useRouter()
 
@@ -47,6 +63,11 @@ const MyLike = ({ items, sortBy, checkedMap, onToggleOne }: MyLikeProps) => {
     <div>
       {sortedItems.map((post) => {
         const id = String(post.id)
+
+        const rawThumb =
+          typeof post.thumbnail === 'string' ? post.thumbnail : ''
+        const thumb = normalizeThumbUrl(rawThumb)
+        const hasThumb = thumb.length > 0
 
         return (
           <div
@@ -105,15 +126,29 @@ const MyLike = ({ items, sortBy, checkedMap, onToggleOne }: MyLikeProps) => {
                   </div>
                 </div>
 
-                <div className="bg-brand-gray-100 relative hidden h-30 w-30 shrink-0 overflow-hidden rounded-lg md:block">
-                  <Image
-                    src={post.thumbnail}
-                    alt="thumbnail"
-                    fill
-                    sizes="120px"
-                    className="object-cover"
-                  />
-                </div>
+                {hasThumb && (
+                  <div className="bg-brand-gray-100 relative hidden h-30 w-30 shrink-0 overflow-hidden rounded-lg md:block">
+                    {isSvgUrl(thumb) ? (
+                      <>
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={thumb}
+                          alt="thumbnail"
+                          className="h-full w-full object-cover"
+                          loading="lazy"
+                        />
+                      </>
+                    ) : (
+                      <Image
+                        src={thumb}
+                        alt="thumbnail"
+                        fill
+                        sizes="120px"
+                        className="object-cover"
+                      />
+                    )}
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/features/mypage/ui/MyPage.tsx
+++ b/src/features/mypage/ui/MyPage.tsx
@@ -1,413 +1,45 @@
 'use client'
 
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from 'react'
-import { toast } from 'sonner'
-
-import PostFilter, { type SortOption } from '@/features/mypage/ui/PostFilter'
+import PostFilter from '@/features/mypage/ui/PostFilter'
 import MyPost from '@/features/mypage/ui/MyPost'
 import MyComment from '@/features/mypage/ui/MyComment'
 import MyLike from '@/features/mypage/ui/MyLike'
 import MyPageActionMenu from '@/features/mypage/ui/MyPageActionMenu'
 import { Pagination } from '@/shared/ui/pagination-je'
 import Profile from '@/features/mypage/ui/Profile'
-import TimeLine, { type TimelineItem } from '@/features/mypage/ui/TimeLine'
-import type {
-  MyCommentItem,
-  MyPagePostItem,
-} from '@/entities/mypage/model/mypage-ui-types'
-import { useSessionStore } from '@/entities/session/store/session-store'
-import { useMyPosts } from '@/features/mypage/hook/useMyPost'
-import { useMyComments } from '@/features/mypage/hook/useMyComments'
-import { useLikedPosts } from '@/features/mypage/hook/useLikes'
-import { useDeleteMyPosts } from '@/features/mypage/hook/useDeleteMyPost'
-import { useDeleteMyComments } from '@/features/mypage/hook/useDeleteMyComments'
-import { useTimelineHistory } from '@/features/mypage/hook/useTimeline'
+import TimeLine from '@/features/mypage/ui/TimeLine'
 
-type TabType = 'post' | 'comment' | 'like'
-
-const normalize = (v: unknown) =>
-  String(v ?? '')
-    .trim()
-    .toLowerCase()
-
-const formatDateParts = (input: string): { date: string; time: string } => {
-  const dateObj = new Date(input)
-  if (Number.isNaN(dateObj.getTime())) return { date: '', time: '' }
-  const yyyy = dateObj.getFullYear()
-  const mm = String(dateObj.getMonth() + 1).padStart(2, '0')
-  const dd = String(dateObj.getDate()).padStart(2, '0')
-  const hh = String(dateObj.getHours()).padStart(2, '0')
-  const min = String(dateObj.getMinutes()).padStart(2, '0')
-  return { date: `${yyyy}.${mm}.${dd}`, time: `${hh}:${min}` }
-}
-
-const getKstNow = () => {
-  const now = new Date()
-  const utc = now.getTime() + now.getTimezoneOffset() * 60_000
-  return new Date(utc + 9 * 60 * 60_000)
-}
-
-const startOfKstDay = () => {
-  const d = getKstNow()
-  d.setHours(0, 0, 0, 0)
-  return d
-}
-
-const addDays = (base: Date, offset: number) => {
-  const d = new Date(base)
-  d.setDate(base.getDate() + offset)
-  return d
-}
-
-const toYmd = (d: Date) => {
-  const yyyy = d.getFullYear()
-  const mm = String(d.getMonth() + 1).padStart(2, '0')
-  const dd = String(d.getDate()).padStart(2, '0')
-  return `${yyyy}-${mm}-${dd}`
-}
-
-const toMmDd = (d: Date) => {
-  const mm = String(d.getMonth() + 1).padStart(2, '0')
-  const dd = String(d.getDate()).padStart(2, '0')
-  return `${mm}.${dd}`
-}
-
-const toKoreanDay = (d: Date) => {
-  const days = ['일', '월', '화', '수', '목', '금', '토'] as const
-  return days[d.getDay()]
-}
-
-const DEFAULT_THUMBNAIL = '/images/mypage/post-example.png'
-const DEFAULT_AVATAR = '/images/profiles/default-1.webp'
+import { useMyPageController } from '@/features/mypage/hook/useMyPageController'
 
 const MyPage = () => {
-  const [tab, setTab] = useState<TabType>('post')
-  const [page, setPage] = useState(1)
-
-  const [selectedBoard, setSelectedBoard] = useState('')
-  const [search, setSearch] = useState('')
-
-  const [sortBy, setSortBy] = useState<SortOption>('latest')
-  const [checkedMap, setCheckedMap] = useState<Record<string, boolean>>({})
-
-  const sessionUser = useSessionStore((s) => s.user)
-  const isClient = useSyncExternalStore(
-    (onStoreChange) => {
-      queueMicrotask(onStoreChange)
-      return () => {}
-    },
-    () => true,
-    () => false
-  )
-
-  const user = isClient ? sessionUser : null
-
-  const myPostsQuery = useMyPosts(
-    { page, size: 10, sort: sortBy },
-    { enabled: isClient && tab === 'post' }
-  )
-  const myCommentsQuery = useMyComments(
-    { page, size: 15, sort: sortBy },
-    { enabled: isClient && tab === 'comment' }
-  )
-  const likedPostsQuery = useLikedPosts(
-    { page, size: 10, sort: sortBy },
-    { enabled: isClient && tab === 'like' }
-  )
-
-  const deleteMyPosts = useDeleteMyPosts()
-  const deleteMyComments = useDeleteMyComments()
-
-  const lastErrorKeyRef = useRef<string | null>(null)
-
-  const timelineHistoryQuery = useTimelineHistory(isClient)
-
-  const noHistoryToastOnceRef = useRef(false)
-  useEffect(() => {
-    if (!timelineHistoryQuery.isSuccess) return
-    if (noHistoryToastOnceRef.current) return
-
-    const results = timelineHistoryQuery.data?.results ?? []
-    if (results.length === 0) {
-      noHistoryToastOnceRef.current = true
-      toast('아직 출석 기록이 없습니다')
-    }
-  }, [timelineHistoryQuery.isSuccess, timelineHistoryQuery.data?.results])
-
-  const timeline = useMemo<TimelineItem[]>(() => {
-    const today = startOfKstDay()
-    const results = timelineHistoryQuery.data?.results ?? []
-
-    const submittedMap = new Map<string, boolean>()
-    for (const r of results) submittedMap.set(r.date, !!r.is_submitted)
-
-    const items: TimelineItem[] = []
-    for (let offset = -3; offset <= 3; offset += 1) {
-      const d = addDays(today, offset)
-      const ymd = toYmd(d)
-      const submitted = submittedMap.get(ymd) ?? false
-
-      let status: TimelineItem['status'] = 'upcoming'
-      if (offset > 0) status = 'upcoming'
-      else if (offset === 0) status = submitted ? 'done' : 'go'
-      else status = submitted ? 'done' : 'fail'
-
-      items.push({
-        date: toMmDd(d),
-        day: toKoreanDay(d),
-        status,
-      })
-    }
-
-    return items
-  }, [timelineHistoryQuery.data?.results])
-
-  const profile = useMemo(() => {
-    return {
-      nickname: user?.nickname ?? '',
-      email: user?.email ?? '',
-      joinedAt: '-',
-      profileImageSrc: user?.profileImageUrl ?? null,
-      balloonLeft: {
-        title: '오늘도 힘내봐요!',
-        subtitle: 'Hazlo lo mejor que puedas hoy también',
-      },
-      balloonRight: {
-        title: 'STUDY GO !',
-      },
-    }
-  }, [user?.email, user?.nickname, user?.profileImageUrl])
-
-  const posts = useMemo<MyPagePostItem[]>(() => {
-    const author = user?.nickname ?? ''
-    const avatar = user?.profileImageUrl
-    const safeAvatar = avatar ?? DEFAULT_AVATAR
-
-    return (myPostsQuery.data?.posts ?? []).map((p) => {
-      const { date, time } = formatDateParts(p.createdAt)
-      return {
-        id: p.id,
-        author,
-        date,
-        time,
-        title: p.title,
-        views: 0,
-        likes: 0,
-        comments: 0,
-        avatar: safeAvatar,
-        thumbnail: DEFAULT_THUMBNAIL,
-        board: 'free',
-      }
-    })
-  }, [myPostsQuery.data?.posts, user?.nickname, user?.profileImageUrl])
-
-  const likedPosts = useMemo<MyPagePostItem[]>(() => {
-    const author = user?.nickname ?? ''
-    const avatar = user?.profileImageUrl
-    const safeAvatar = avatar ?? DEFAULT_AVATAR
-
-    return (likedPostsQuery.data?.posts ?? []).map((p) => {
-      const createdAt = p.likedAt ?? p.createdAt ?? ''
-      const { date, time } = formatDateParts(createdAt)
-      return {
-        id: p.id,
-        author,
-        date,
-        time,
-        title: p.title,
-        views: 0,
-        likes: 0,
-        comments: 0,
-        avatar: safeAvatar,
-        thumbnail: DEFAULT_THUMBNAIL,
-        board: 'free',
-      }
-    })
-  }, [likedPostsQuery.data?.posts, user?.nickname, user?.profileImageUrl])
-
-  const comments = useMemo<MyCommentItem[]>(() => {
-    const safe = myCommentsQuery.data?.comments ?? []
-    return safe.map((c) => {
-      return {
-        commentId: String(c.id),
-        postId: c.postId == null ? null : String(c.postId),
-        postTitle: c.postTitle ?? null,
-        content: c.content ?? null,
-        createdAt: c.createdAt,
-        board: null,
-      }
-    })
-  }, [myCommentsQuery.data?.comments])
-
-  const filteredPosts = useMemo(() => {
-    const board = normalize(selectedBoard)
-    const q = normalize(search)
-
-    return posts.filter((p) => {
-      const okBoard = !board || normalize(p.board) === board
-      const okSearch =
-        !q || normalize(p.title).includes(q) || normalize(p.author).includes(q)
-      return okBoard && okSearch
-    })
-  }, [posts, selectedBoard, search])
-
-  const filteredLikes = useMemo(() => {
-    const board = normalize(selectedBoard)
-    const q = normalize(search)
-
-    return likedPosts.filter((p) => {
-      const okBoard = !board || normalize(p.board) === board
-      const okSearch =
-        !q || normalize(p.title).includes(q) || normalize(p.author).includes(q)
-      return okBoard && okSearch
-    })
-  }, [likedPosts, selectedBoard, search])
-
-  const filteredComments = useMemo(() => {
-    const board = normalize(selectedBoard)
-    const q = normalize(search)
-
-    return comments.filter((c) => {
-      const okBoard = !board || normalize(c.board) === board
-      const okSearch =
-        !q ||
-        normalize(c.postTitle).includes(q) ||
-        normalize(c.content).includes(q)
-      return okBoard && okSearch
-    })
-  }, [comments, selectedBoard, search])
-
-  useEffect(() => {
-    const isError =
-      (tab === 'post' && myPostsQuery.isError) ||
-      (tab === 'comment' && myCommentsQuery.isError) ||
-      (tab === 'like' && likedPostsQuery.isError)
-
-    if (!isError) {
-      lastErrorKeyRef.current = null
-      return
-    }
-
-    const error =
-      (tab === 'post' && myPostsQuery.error) ||
-      (tab === 'comment' && myCommentsQuery.error) ||
-      (tab === 'like' && likedPostsQuery.error)
-
-    const message =
-      error instanceof Error ? error.message : error ? String(error) : ''
-    const errorKey = `${tab}:${message}`
-
-    if (lastErrorKeyRef.current === errorKey) return
-    lastErrorKeyRef.current = errorKey
-
-    if (message) {
-      console.error('[MyPage] query error:', error)
-      toast.error(`마이페이지 데이터를 불러오지 못했습니다. (${message})`)
-    } else {
-      toast.error('마이페이지 데이터를 불러오지 못했습니다.')
-    }
-  }, [
+  const {
     tab,
-    myPostsQuery.error,
-    myPostsQuery.isError,
-    myCommentsQuery.error,
-    myCommentsQuery.isError,
-    likedPostsQuery.error,
-    likedPostsQuery.isError,
-  ])
+    page,
+    selectedBoard,
+    search,
+    sortBy,
+    checkedMap,
 
-  const handleChangeTab = (nextTab: TabType) => {
-    setTab(nextTab)
-    setPage(1)
-    setCheckedMap({})
-  }
+    user,
+    profile,
+    timeline,
 
-  const handleChangeSortBy = (next: SortOption) => {
-    setSortBy(next)
-    setPage(1)
-    setCheckedMap({})
-  }
+    filteredPosts,
+    filteredComments,
+    filteredLikes,
 
-  const handleChangeBoard = (value: string) => {
-    setSelectedBoard(value)
-    setPage(1)
-    setCheckedMap({})
-  }
+    totalPages,
+    actionLabel,
+    isCurrentTabLoading,
 
-  const handleChangeSearch = (value: string) => {
-    setSearch(value)
-    setPage(1)
-    setCheckedMap({})
-  }
-
-  const handleToggleOne = (id: string) => {
-    setCheckedMap((prev) => ({
-      ...prev,
-      [id]: !prev[id],
-    }))
-  }
-
-  const actionLabel = tab === 'like' ? '해지하기' : '삭제하기'
-
-  const handleClickAction = async () => {
-    const selectedIds = Object.entries(checkedMap)
-      .filter(([, v]) => v)
-      .map(([id]) => Number(id))
-      .filter((id) => Number.isFinite(id))
-
-    const selectedCount = selectedIds.length
-
-    if (selectedCount === 0) {
-      toast.error('선택된 항목이 없습니다.')
-      return
-    }
-
-    try {
-      if (tab === 'post') {
-        await deleteMyPosts.mutateAsync(selectedIds)
-        toast.success('선택한 게시글을 삭제했습니다.')
-        setCheckedMap({})
-        return
-      }
-
-      if (tab === 'comment') {
-        await deleteMyComments.mutateAsync(selectedIds)
-        toast.success('선택한 댓글을 삭제했습니다.')
-        setCheckedMap({})
-        return
-      }
-
-      toast.success('좋아요를 해지했습니다.')
-      setCheckedMap({})
-    } catch {
-      toast.error('요청 처리에 실패했습니다.')
-    }
-  }
-
-  const totalPages = useMemo(() => {
-    if (tab === 'post') return myPostsQuery.data?.pagination.totalPages ?? 1
-    if (tab === 'comment')
-      return myCommentsQuery.data?.pagination.totalPages ?? 1
-    if (tab === 'like') return likedPostsQuery.data?.pagination.totalPages ?? 1
-    return 1
-  }, [
-    tab,
-    myPostsQuery.data?.pagination.totalPages,
-    myCommentsQuery.data?.pagination.totalPages,
-    likedPostsQuery.data?.pagination.totalPages,
-  ])
-
-  const isCurrentTabLoading =
-    !isClient ||
-    (tab === 'post' && myPostsQuery.isLoading) ||
-    (tab === 'comment' && myCommentsQuery.isLoading) ||
-    (tab === 'like' && likedPostsQuery.isLoading)
+    setPage,
+    handleChangeTab,
+    handleChangeBoard,
+    handleChangeSearch,
+    handleChangeSortBy,
+    handleToggleOne,
+    handleClickAction,
+  } = useMyPageController()
 
   return (
     <div className="bg-brand-white min-h-screen">

--- a/src/features/mypage/ui/MyPage.tsx
+++ b/src/features/mypage/ui/MyPage.tsx
@@ -371,19 +371,19 @@ const MyPage = () => {
     try {
       if (tab === 'post') {
         await deleteMyPosts.mutateAsync(selectedIds)
-        toast.success('선택한 항목을 삭제했습니다.')
+        toast.success('선택한 게시글을 삭제했습니다.')
         setCheckedMap({})
         return
       }
 
       if (tab === 'comment') {
         await deleteMyComments.mutateAsync(selectedIds)
-        toast.success('선택한 항목을 삭제했습니다.')
+        toast.success('선택한 댓글을 삭제했습니다.')
         setCheckedMap({})
         return
       }
 
-      toast.success('선택한 좋아요를 해지했습니다.')
+      toast.success('좋아요를 해지했습니다.')
       setCheckedMap({})
     } catch {
       toast.error('요청 처리에 실패했습니다.')

--- a/src/features/mypage/ui/MyPost.tsx
+++ b/src/features/mypage/ui/MyPost.tsx
@@ -22,6 +22,22 @@ const getPostTimeMs = (post: MyPagePostItem): number => {
   return Number.isNaN(timestamp) ? 0 : timestamp
 }
 
+const normalizeThumbUrl = (raw: string): string => {
+  const url = raw.trim()
+  if (!url) return ''
+
+  if (
+    url.includes('placehold.co') &&
+    !/\.(png|jpe?g|webp|gif)(\?|$)/i.test(url)
+  ) {
+    return url.replace(/placehold\.co\/(\d+x\d+)(?!\/)/i, 'placehold.co/$1/png')
+  }
+
+  return url
+}
+
+const isSvgUrl = (url: string): boolean => /\.svg(\?|$)/i.test(url)
+
 const MyPost = ({ items, sortBy, checkedMap, onToggleOne }: MyPostProps) => {
   const router = useRouter()
 
@@ -45,6 +61,11 @@ const MyPost = ({ items, sortBy, checkedMap, onToggleOne }: MyPostProps) => {
     <div>
       {sortedItems.map((post) => {
         const id = String(post.id)
+
+        const rawThumb =
+          typeof post.thumbnail === 'string' ? post.thumbnail : ''
+        const thumb = normalizeThumbUrl(rawThumb)
+        const hasThumb = thumb.length > 0
 
         return (
           <div
@@ -103,15 +124,29 @@ const MyPost = ({ items, sortBy, checkedMap, onToggleOne }: MyPostProps) => {
                   </div>
                 </div>
 
-                <div className="bg-brand-gray-100 relative hidden h-30 w-30 shrink-0 overflow-hidden rounded-lg md:block">
-                  <Image
-                    src={post.thumbnail}
-                    alt="thumbnail"
-                    fill
-                    sizes="120px"
-                    className="object-cover"
-                  />
-                </div>
+                {hasThumb && (
+                  <div className="bg-brand-gray-100 relative hidden h-30 w-30 shrink-0 overflow-hidden rounded-lg md:block">
+                    {isSvgUrl(thumb) ? (
+                      <>
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={thumb}
+                          alt="thumbnail"
+                          className="h-full w-full object-cover"
+                          loading="lazy"
+                        />
+                      </>
+                    ) : (
+                      <Image
+                        src={thumb}
+                        alt="thumbnail"
+                        fill
+                        sizes="120px"
+                        className="object-cover"
+                      />
+                    )}
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/shared/api/mocks/handlers/handlers.ts
+++ b/src/shared/api/mocks/handlers/handlers.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse, passthrough } from 'msw'
 import { communityHandlers } from '@/shared/api/mocks/handlers/community-handlers'
 import { chatHandlers } from '@/shared/api/mocks/handlers/chat-handlers'
-import { mypageHandlers } from '@/shared/api/mocks/handlers/mypage-handlers'
+// import { mypageHandlers } from '@/shared/api/mocks/handlers/mypage-handlers'
 // import { authHandlers } from '@/shared/api/mocks/handlers/auth-handlers'
 
 const handlers = [
@@ -16,7 +16,7 @@ const handlers = [
 
   ...communityHandlers,
   ...chatHandlers,
-  ...mypageHandlers,
+  // ...mypageHandlers,
 
   // ...authHandlers,
 ]


### PR DESCRIPTION
## #️⃣연관된 이슈

> #141 

## 📝작업 내용

> 마이페이지 리팩토링 및 데이터 연동 정리
- 마이페이지 내 게시글 / 좋아요 목록에서 조회수, 좋아요 수, 댓글 수가 실제 API 응답값과 연동되도록 수정
- 0으로 고정되어 있던 카운트 데이터를 제거하고, 공통 데이터 가공 로직으로 통합
- 마이페이지 관련 로직을 훅 단위로 분리하여 가독성과 유지보수성 개선
- MyPage.tsx를 포함한 마이페이지 UI 컴포넌트들의 역할을 명확히 분리
- 썸네일 이미지 렌더링 로직 개선 및 콘텐츠 프리뷰 처리 정리
- 좋아요 목록 API 응답 구조 변경에 맞춰 프론트 데이터 처리 로직 정규화
- 내 댓글 목록에서 삭제된 댓글 처리 및 오판 처리 로직 수정
- 마이페이지 관련 MSW 목 데이터 및 주석 정리

## 🖼️스크린샷

> 생략하겠습니다...

## 💬리뷰 요구사항 (선택)

## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
