### PR TITLE
[Feature] 회원탈퇴 인증 토큰 발급 및 탈퇴 API 연동 (#149)

### DIFF
--- a/src/entities/mypage-my-information-fix/api/withdrawal-api.ts
+++ b/src/entities/mypage-my-information-fix/api/withdrawal-api.ts
@@ -1,0 +1,17 @@
+import { api } from '@/shared/api/client'
+import {
+  WithdrawalRequestSchema,
+  WithdrawalResponseSchema,
+  type WithdrawalRequest,
+  type WithdrawalResponse,
+} from '@/entities/mypage-my-information-fix/model/withdrawal-schema'
+
+export async function postWithdrawalApi(
+  request: WithdrawalRequest
+): Promise<WithdrawalResponse> {
+  const validatedRequest = WithdrawalRequestSchema.parse(request)
+
+  const response = await api.post<unknown>('/auth/withdrawal', validatedRequest)
+
+  return WithdrawalResponseSchema.parse(response.data)
+}

--- a/src/entities/mypage-my-information-fix/api/withdrawal-token-api.ts
+++ b/src/entities/mypage-my-information-fix/api/withdrawal-token-api.ts
@@ -1,0 +1,25 @@
+import { api } from '@/shared/api/client'
+import {
+  WithdrawalTokenStepSchema,
+  WithdrawalTokenByPasswordRequestSchema,
+  WithdrawalTokenByPasswordResponseSchema,
+  type WithdrawalTokenStep,
+  type WithdrawalTokenByPasswordRequest,
+  type WithdrawalTokenByPasswordResponse,
+} from '@/entities/mypage-my-information-fix/model/withdrawal-token-schema'
+
+export async function getWithdrawalTokenStepApi(): Promise<WithdrawalTokenStep> {
+  const response = await api.get<unknown>('/auth/withdrawal-token')
+  return WithdrawalTokenStepSchema.parse(response.data)
+}
+
+export async function postWithdrawalTokenByPasswordApi(
+  request: WithdrawalTokenByPasswordRequest
+): Promise<WithdrawalTokenByPasswordResponse> {
+  const validated = WithdrawalTokenByPasswordRequestSchema.parse(request)
+  const response = await api.post<unknown>(
+    '/auth/withdrawal-token/password',
+    validated
+  )
+  return WithdrawalTokenByPasswordResponseSchema.parse(response.data)
+}

--- a/src/entities/mypage-my-information-fix/model/withdrawal-schema.ts
+++ b/src/entities/mypage-my-information-fix/model/withdrawal-schema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+export const WithdrawalRequestSchema = z.object({
+  withdrawal_token: z.string().min(1, 'withdrawal_token은 필수입니다.'),
+})
+
+export type WithdrawalRequest = z.infer<typeof WithdrawalRequestSchema>
+
+export const WithdrawalResponseSchema = z.object({
+  detail: z.string(),
+})
+
+export type WithdrawalResponse = z.infer<typeof WithdrawalResponseSchema>
+
+export const WithdrawalErrorResponseSchema = z.object({
+  detail: z.string(),
+})
+
+export type WithdrawalErrorResponse = z.infer<
+  typeof WithdrawalErrorResponseSchema
+>

--- a/src/entities/mypage-my-information-fix/model/withdrawal-token-schema.ts
+++ b/src/entities/mypage-my-information-fix/model/withdrawal-token-schema.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+export const WithdrawalTokenStepSchema = z.union([
+  z.object({
+    next_step: z.literal('password'),
+  }),
+  z.object({
+    next_step: z.literal('social'),
+    providers: z.array(z.enum(['google', 'kakao'])),
+  }),
+])
+
+export type WithdrawalTokenStep = z.infer<typeof WithdrawalTokenStepSchema>
+
+export const WithdrawalTokenByPasswordRequestSchema = z.object({
+  password: z.string().min(1, 'password는 필수입니다.'),
+})
+
+export type WithdrawalTokenByPasswordRequest = z.infer<
+  typeof WithdrawalTokenByPasswordRequestSchema
+>
+
+export const WithdrawalTokenByPasswordResponseSchema = z.object({
+  withdrawal_token: z.string(),
+  expires_in: z.number().int(),
+})
+
+export type WithdrawalTokenByPasswordResponse = z.infer<
+  typeof WithdrawalTokenByPasswordResponseSchema
+>
+
+export const WithdrawalTokenErrorResponseSchema = z.object({
+  detail: z.string(),
+})
+
+export type WithdrawalTokenErrorResponse = z.infer<
+  typeof WithdrawalTokenErrorResponseSchema
+>

--- a/src/features/mypage-my-information-fix/hook/useWithdrawal.ts
+++ b/src/features/mypage-my-information-fix/hook/useWithdrawal.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query'
+import { postWithdrawalApi } from '@/entities/mypage-my-information-fix/api/withdrawal-api'
+import type {
+  WithdrawalRequest,
+  WithdrawalResponse,
+} from '@/entities/mypage-my-information-fix/model/withdrawal-schema'
+export function useWithdrawal() {
+  return useMutation<WithdrawalResponse, unknown, WithdrawalRequest>({
+    mutationFn: postWithdrawalApi,
+  })
+}

--- a/src/features/mypage-my-information-fix/hook/useWithdrawalTokenByPassword.ts
+++ b/src/features/mypage-my-information-fix/hook/useWithdrawalTokenByPassword.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query'
+import { postWithdrawalTokenByPasswordApi } from '@/entities/mypage-my-information-fix/api/withdrawal-token-api'
+import type {
+  WithdrawalTokenByPasswordRequest,
+  WithdrawalTokenByPasswordResponse,
+} from '@/entities/mypage-my-information-fix/model/withdrawal-token-schema'
+
+export function useWithdrawalTokenByPassword() {
+  return useMutation<
+    WithdrawalTokenByPasswordResponse,
+    unknown,
+    WithdrawalTokenByPasswordRequest
+  >({
+    mutationFn: postWithdrawalTokenByPasswordApi,
+  })
+}

--- a/src/features/mypage-my-information-fix/hook/useWithdrawalTokenStep.ts
+++ b/src/features/mypage-my-information-fix/hook/useWithdrawalTokenStep.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query'
+import { getWithdrawalTokenStepApi } from '@/entities/mypage-my-information-fix/api/withdrawal-token-api'
+
+export function useWithdrawalTokenStep(enabled: boolean) {
+  return useQuery({
+    queryKey: ['auth', 'withdrawal-token-step'],
+    queryFn: getWithdrawalTokenStepApi,
+    enabled,
+    staleTime: 0,
+    gcTime: 0,
+  })
+}

--- a/src/features/mypage-my-information-fix/lib/normalize-withdrawal-error.ts
+++ b/src/features/mypage-my-information-fix/lib/normalize-withdrawal-error.ts
@@ -1,0 +1,11 @@
+import axios from 'axios'
+import { WithdrawalErrorResponseSchema } from '@/entities/mypage-my-information-fix/model/withdrawal-schema'
+
+export function normalizeWithdrawalError(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const parsed = WithdrawalErrorResponseSchema.safeParse(error.response?.data)
+    if (parsed.success) return parsed.data.detail
+  }
+
+  return '회원탈퇴에 실패했습니다. 다시 시도해주세요.'
+}

--- a/src/features/mypage-my-information-fix/lib/normalize-withdrawal-token-error.ts
+++ b/src/features/mypage-my-information-fix/lib/normalize-withdrawal-token-error.ts
@@ -1,0 +1,12 @@
+import axios from 'axios'
+import { WithdrawalTokenErrorResponseSchema } from '@/entities/mypage-my-information-fix/model/withdrawal-token-schema'
+
+export function normalizeWithdrawalTokenError(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const parsed = WithdrawalTokenErrorResponseSchema.safeParse(
+      error.response?.data
+    )
+    if (parsed.success) return parsed.data.detail
+  }
+  return '회원탈퇴 인증 처리에 실패했습니다.'
+}

--- a/src/features/mypage-my-information-fix/ui/MyInformationFix.tsx
+++ b/src/features/mypage-my-information-fix/ui/MyInformationFix.tsx
@@ -61,8 +61,10 @@ function normalizeProfileImageUrlForApi(
 
 function MyInformationFixContent({
   userProfile,
+  onOpenWithdraw,
 }: {
   userProfile: UserProfile
+  onOpenWithdraw: () => void
 }) {
   const router = useRouter()
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -429,7 +431,7 @@ function MyInformationFixContent({
         />
 
         <FooterSection
-          onOpenWithdraw={() => {}}
+          onOpenWithdraw={onOpenWithdraw}
           onClickSave={handleSave}
           isSaving={isSaving}
         />
@@ -462,7 +464,10 @@ export function MyInformationFix() {
 
   return (
     <>
-      <MyInformationFixContent userProfile={userProfile} />
+      <MyInformationFixContent
+        userProfile={userProfile}
+        onOpenWithdraw={() => setIsWithdrawOpen(true)}
+      />
 
       <WithdrawFlowModal
         isOpen={isWithdrawOpen}

--- a/src/features/mypage-my-information-fix/ui/WithdrawConfirmModal.tsx
+++ b/src/features/mypage-my-information-fix/ui/WithdrawConfirmModal.tsx
@@ -11,12 +11,14 @@ interface WithdrawConfirmModalProps {
   isOpen: boolean
   onClose: () => void
   onConfirm: () => void
+  isPending: boolean
 }
 
 export function WithdrawConfirmModal({
   isOpen,
   onClose,
   onConfirm,
+  isPending,
 }: WithdrawConfirmModalProps) {
   const [enabled, setEnabled] = useState(false)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -37,6 +39,8 @@ export function WithdrawConfirmModal({
   }, [isOpen])
 
   const handleClose = () => {
+    if (isPending) return
+
     setEnabled(false)
     if (timerRef.current) {
       clearTimeout(timerRef.current)
@@ -46,6 +50,8 @@ export function WithdrawConfirmModal({
   }
 
   const handleConfirm = () => {
+    if (isPending) return
+
     setEnabled(false)
     if (timerRef.current) {
       clearTimeout(timerRef.current)
@@ -83,6 +89,7 @@ export function WithdrawConfirmModal({
           size="md"
           className="flex-1"
           onClick={handleClose}
+          disabled={isPending}
         >
           취소
         </Button>
@@ -93,7 +100,7 @@ export function WithdrawConfirmModal({
           size="md"
           className={cn('flex-1', 'bg-brand-main hover:bg-brand-main/90')}
           onClick={handleConfirm}
-          disabled={!enabled}
+          disabled={!enabled || isPending}
         >
           탈퇴하기
         </Button>

--- a/src/features/mypage-my-information-fix/ui/WithdrawFlowModal.tsx
+++ b/src/features/mypage-my-information-fix/ui/WithdrawFlowModal.tsx
@@ -1,26 +1,49 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+
 import { Modal } from '@/shared/ui/Modal'
 import { Button } from '@/shared/ui/Button'
 import { Input } from '@/shared/ui/input'
 import { cn } from '@/shared/lib/cn'
-
 import { Dropdown } from '@/shared/ui/dropdown/Dropdown'
 
-import { WithdrawConfirmModal } from './WithdrawConfirmModal'
+import { WithdrawConfirmModal } from '@/features/mypage-my-information-fix/ui/WithdrawConfirmModal'
 import {
   REASON_LABEL,
   type WithdrawalReason,
 } from '@/features/mypage-my-information-fix/ui/withdraw-types'
-import { toast } from 'sonner'
+
+import { normalizeWithdrawalTokenError } from '@/features/mypage-my-information-fix/lib/normalize-withdrawal-token-error'
+import { normalizeWithdrawalError } from '@/features/mypage-my-information-fix/lib/normalize-withdrawal-error'
+import { useWithdrawalTokenStep } from '../hook/useWithdrawalTokenStep'
+import { useWithdrawal } from '../hook/useWithdrawal'
+import { useWithdrawalTokenByPassword } from '../hook/useWithdrawalTokenByPassword'
 
 type Step = 'GUIDE' | 'REASON' | 'PASSWORD'
 
 interface WithdrawFlowModalProps {
   isOpen: boolean
   onClose: () => void
+}
+
+function buildWithdrawalSocialReauthUrl(provider: 'google' | 'kakao'): string {
+  const baseUrlFromEnv = process.env.NEXT_PUBLIC_API_BASE_URL
+  const base = typeof baseUrlFromEnv === 'string' ? baseUrlFromEnv : ''
+
+  // base가 '.../api/v1' 를 포함하는 경우가 많아서 안전하게 정리
+  const trimmedBase = base.endsWith('/') ? base.slice(0, -1) : base
+  const baseWithoutApiV1 = trimmedBase.endsWith('/api/v1')
+    ? trimmedBase.slice(0, -'/api/v1'.length)
+    : trimmedBase
+
+  if (baseWithoutApiV1.length === 0) {
+    return `/api/v1/oauth/${provider}/callback?purpose=withdrawal`
+  }
+
+  return `${baseWithoutApiV1}/api/v1/oauth/${provider}/callback?purpose=withdrawal`
 }
 
 export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
@@ -32,16 +55,24 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
   const [agree2, setAgree2] = useState(false)
 
   // 탈퇴사유 2
-  const [reason, setReason] = useState<WithdrawalReason>('') // '' = 선택 안 함(placeholder)
+  const [reason, setReason] = useState<WithdrawalReason>('')
   const [etcText, setEtcText] = useState('')
 
-  // 비밀번호 3
+  // 비밀번호 3 (명세상: 비밀번호로 "탈퇴 인증 토큰" 발급)
   const [password, setPassword] = useState('')
 
   // 경고창 4
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
 
-  // 1
+  const { data: tokenStepData, isError: isTokenStepError } =
+    useWithdrawalTokenStep(isOpen)
+
+  const tokenByPasswordMutation = useWithdrawalTokenByPassword()
+  const withdrawalMutation = useWithdrawal()
+
+  const isPending =
+    tokenByPasswordMutation.isPending || withdrawalMutation.isPending
+
   const reset = () => {
     setStep('GUIDE')
     setAgree1(false)
@@ -50,14 +81,33 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
     setEtcText('')
     setPassword('')
     setIsConfirmOpen(false)
+    tokenByPasswordMutation.reset()
+    withdrawalMutation.reset()
   }
 
   const handleClose = () => {
+    if (isPending) return
     reset()
     onClose()
   }
 
-  if (!isOpen) return null
+  useEffect(() => {
+    if (!isOpen) return
+    if (isTokenStepError) return
+    if (!tokenStepData) return
+
+    if (tokenStepData.next_step === 'social') {
+      const provider = tokenStepData.providers[0]
+      if (!provider) {
+        toast.error('소셜 재인증 제공자를 찾을 수 없습니다.')
+        return
+      }
+
+      toast.message('회원탈퇴를 위해 소셜 재인증이 필요합니다.')
+      const url = buildWithdrawalSocialReauthUrl(provider)
+      window.location.href = url
+    }
+  }, [isOpen, isTokenStepError, tokenStepData])
 
   const canNextGuide = agree1 && agree2
   const etcTooLong = etcText.length > 500
@@ -65,11 +115,19 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
   const canNextPassword = password.trim().length > 0
 
   const goPrev = () => {
+    if (isPending) return
     if (step === 'REASON') setStep('GUIDE')
     else if (step === 'PASSWORD') setStep('REASON')
   }
 
   const goNext = () => {
+    if (isPending) return
+
+    if (tokenStepData?.next_step === 'social') {
+      // 소셜은 useEffect에서 바로 이동 처리한다.
+      return
+    }
+
     if (step === 'GUIDE') {
       if (!canNextGuide) return
       setStep('REASON')
@@ -89,13 +147,52 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
   }
 
   const handleConfirmWithdraw = () => {
-    // TODO: API 연동 자리
-    setIsConfirmOpen(false)
-    toast.success('회원탈퇴 처리 완료되었습니다.')
-    reset()
-    onClose()
-    router.replace('/')
+    if (isPending) return
+
+    if (!tokenStepData) {
+      toast.error('회원탈퇴 인증 정보를 불러오지 못했습니다.')
+      return
+    }
+
+    if (tokenStepData.next_step !== 'password') {
+      toast.error('비밀번호 인증이 필요한 계정이 아닙니다.')
+      return
+    }
+
+    const trimmedPassword = password.trim()
+    if (trimmedPassword.length === 0) {
+      toast.error('비밀번호를 입력해 주세요.')
+      return
+    }
+
+    tokenByPasswordMutation.mutate(
+      { password: trimmedPassword },
+      {
+        onSuccess: (tokenRes) => {
+          withdrawalMutation.mutate(
+            { withdrawal_token: tokenRes.withdrawal_token },
+            {
+              onSuccess: (withdrawRes) => {
+                setIsConfirmOpen(false)
+                toast.success(withdrawRes.detail)
+                reset()
+                onClose()
+                router.replace('/')
+              },
+              onError: (error) => {
+                toast.error(normalizeWithdrawalError(error))
+              },
+            }
+          )
+        },
+        onError: (error) => {
+          toast.error(normalizeWithdrawalTokenError(error))
+        },
+      }
+    )
   }
+
+  if (!isOpen) return null
 
   return (
     <>
@@ -167,7 +264,7 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
                 size="reg"
                 className="w-full"
                 onClick={goNext}
-                disabled={!canNextGuide}
+                disabled={!canNextGuide || isPending}
               >
                 다음
               </Button>
@@ -175,7 +272,6 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
           </div>
         )}
 
-        {/* 2 */}
         {step === 'REASON' && (
           <div>
             <p className="text-brand-black font-bold">탈퇴사유</p>
@@ -225,6 +321,7 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
                 size="md"
                 className="flex-1"
                 onClick={goPrev}
+                disabled={isPending}
               >
                 이전
               </Button>
@@ -234,7 +331,7 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
                 size="md"
                 className={cn('flex-1', 'bg-brand-main hover:bg-brand-main/90')}
                 onClick={goNext}
-                disabled={!canNextReason}
+                disabled={!canNextReason || isPending}
               >
                 다음
               </Button>
@@ -242,7 +339,6 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
           </div>
         )}
 
-        {/* 3 */}
         {step === 'PASSWORD' && (
           <div>
             <p className="text-brand-gray-400 mb-2 text-sm">비밀번호</p>
@@ -252,6 +348,7 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="비밀번호를 입력해주세요"
+              disabled={isPending}
             />
 
             <div className="mt-6 flex gap-3">
@@ -261,6 +358,7 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
                 size="md"
                 className="flex-1"
                 onClick={goPrev}
+                disabled={isPending}
               >
                 이전
               </Button>
@@ -270,7 +368,7 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
                 size="md"
                 className={cn('flex-1', 'bg-brand-main hover:bg-brand-main/90')}
                 onClick={goNext}
-                disabled={!canNextPassword}
+                disabled={!canNextPassword || isPending}
               >
                 다음
               </Button>
@@ -279,11 +377,14 @@ export function WithdrawFlowModal({ isOpen, onClose }: WithdrawFlowModalProps) {
         )}
       </Modal>
 
-      {/* 4 */}
       <WithdrawConfirmModal
         isOpen={isConfirmOpen}
-        onClose={() => setIsConfirmOpen(false)}
+        onClose={() => {
+          if (isPending) return
+          setIsConfirmOpen(false)
+        }}
         onConfirm={handleConfirmWithdraw}
+        isPending={isPending}
       />
     </>
   )

--- a/src/features/mypage-my-information-fix/ui/sections/FooterSection.tsx
+++ b/src/features/mypage-my-information-fix/ui/sections/FooterSection.tsx
@@ -17,7 +17,7 @@ export function FooterSection({
     <div className="mt-10 flex items-center justify-between">
       <button
         type="button"
-        className="text-brand-gray-300 text-sm underline underline-offset-4"
+        className="text-brand-gray-300 cursor-pointer text-sm underline underline-offset-4"
         onClick={onOpenWithdraw}
       >
         회원탈퇴


### PR DESCRIPTION
## #️⃣연관된 이슈

> #149 

## 📝작업 내용

- 회원탈퇴 플로우 API 연동 구현
- 회원탈퇴 방식 판단 API 연동
- 비밀번호 검증 기반 회원탈퇴 인증 토큰 발급 API 연동
- 회원탈퇴 API 연동
- 회원탈퇴 모달 플로우에 API 호출 연결

## 🖼️스크린샷

> 추후에 추가하겠습니다

## 💬리뷰 요구사항 (선택)


## ✅ 체크리스트

1. 내 브랜치가 최신 브랜치인지 확인
   - [x] `dev` 브랜치로 이동후 `pull`
   - [x] 작업 브랜치로 이동후 `rebase` 해보기

2. 빌드 상의 문제가 있는지 확인
   - [x] `npm run build` 로 빌드 에러가 발생하는지 확인

3. 새로 설치한 패키지가 있다면 팀원들에게 `pull` 받은 후 `npm ci` 해야 한다고 알리기
   - [x] `package.json` / `package-lock.json` 파일이 변동되었는지 확인
   - [x] 변동되었다면 zep 또는 디스코드에서 알리기
